### PR TITLE
Feat/api schedules (#9)

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/calendar/common/Color.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/common/Color.java
@@ -1,5 +1,10 @@
 package com.hanium.mom4u.domain.calendar.common;
 
 public enum Color {
-    RED, BLUE, GREEN, YELLOW, PURPLE
+    sky_blue,
+    aqua_blue,
+    forest,
+    light_green,
+    apricot,
+    cyan
 }

--- a/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
@@ -3,55 +3,85 @@ package com.hanium.mom4u.domain.calendar.controller;
 import com.hanium.mom4u.domain.calendar.dto.request.ScheduleRequest;
 import com.hanium.mom4u.domain.calendar.dto.response.ScheduleResponse;
 import com.hanium.mom4u.domain.calendar.service.ScheduleService;
-import com.hanium.mom4u.domain.member.entity.Member;
-import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import com.hanium.mom4u.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/schedules")
 @RequiredArgsConstructor
+@Tag(name = "일정 API", description = "개인 일정 등록, 조회, 수정, 삭제 API")
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
-    private final MemberRepository memberRepository;
 
-    @GetMapping
-    public List<ScheduleResponse> getAllSchedules() {
-        return scheduleService.getAllSchedules();
+    @Operation(summary = "월별 일정 조회", description = "사용자의 특정 연도/월에 해당하는 모든 일정을 조회합니다.")
+    @GetMapping("/monthly")
+    public ResponseEntity<?> getMonthlySchedules(
+            @RequestParam int year,
+            @RequestParam int month,
+            Authentication authentication
+    ) {
+        List<ScheduleResponse> schedules = scheduleService.getSchedulesByMonth(authentication, year, month);
+        return ResponseEntity.ok(CommonResponse.onSuccess(schedules));
     }
 
+    @Operation(summary = "일별 일정 조회", description = "사용자의 특정 날짜에 해당하는 모든 일정을 조회합니다.")
+    @GetMapping("/daily")
+    public ResponseEntity<?> getDailySchedules(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            Authentication authentication
+    ) {
+        List<ScheduleResponse> schedules = scheduleService.getSchedulesByDate(authentication, date);
+        return ResponseEntity.ok(CommonResponse.onSuccess(schedules));
+    }
+
+    @Operation(summary = "일정 등록", description = "사용자의 새 일정을 생성합니다.")
     @PostMapping
-    public ResponseEntity<Void> createSchedule(
-            @RequestParam Long memberId,
-            @RequestBody ScheduleRequest request
+    public ResponseEntity<?> createSchedule(
+            @RequestBody ScheduleRequest request,
+            Authentication authentication
     ) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
-        scheduleService.createSchedule(request, member);
-        return ResponseEntity.ok().build();
+        scheduleService.createSchedule(request, authentication);
+        return ResponseEntity.ok(CommonResponse.onSuccess());
     }
 
+    @Operation(summary = "일정 수정", description = "지정한 ID의 일정을 수정합니다.")
     @PatchMapping("/{scheduleId}")
-    public ResponseEntity<Void> updateSchedule(
+    public ResponseEntity<?> updateSchedule(
             @PathVariable Long scheduleId,
-            @RequestBody ScheduleRequest request
+            @RequestBody ScheduleRequest request,
+            Authentication authentication
     ) {
-        scheduleService.updateSchedule(scheduleId, request);
-        return ResponseEntity.ok().build();
+        scheduleService.updateSchedule(scheduleId, request, authentication);
+        return ResponseEntity.ok(CommonResponse.onSuccess());
     }
 
+    @Operation(summary = "일정 삭제", description = "지정한 ID의 일정을 삭제합니다.")
     @DeleteMapping("/{scheduleId}")
-    public ResponseEntity<Void> deleteSchedule(@PathVariable Long scheduleId) {
-        scheduleService.deleteSchedule(scheduleId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<?> deleteSchedule(
+            @PathVariable Long scheduleId,
+            Authentication authentication
+    ) {
+        scheduleService.deleteSchedule(scheduleId, authentication);
+        return ResponseEntity.ok(CommonResponse.onSuccess());
     }
 
+    @Operation(summary = "일정 상세 조회", description = "지정한 ID의 일정 정보를 상세 조회합니다.")
     @GetMapping("/{scheduleId}")
-    public ScheduleResponse getScheduleDetail(@PathVariable Long scheduleId) {
-        return scheduleService.getScheduleDetail(scheduleId);
+    public ResponseEntity<?> getScheduleDetail(
+            @PathVariable Long scheduleId,
+            Authentication authentication
+    ) {
+        ScheduleResponse response = scheduleService.getScheduleDetail(scheduleId, authentication);
+        return ResponseEntity.ok(CommonResponse.onSuccess(response));
     }
 }

--- a/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
@@ -1,0 +1,57 @@
+package com.hanium.mom4u.domain.calendar.controller;
+
+import com.hanium.mom4u.domain.calendar.dto.request.ScheduleRequest;
+import com.hanium.mom4u.domain.calendar.dto.response.ScheduleResponse;
+import com.hanium.mom4u.domain.calendar.service.ScheduleService;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+    private final MemberRepository memberRepository;
+
+    @GetMapping
+    public List<ScheduleResponse> getAllSchedules() {
+        return scheduleService.getAllSchedules();
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createSchedule(
+            @RequestParam Long memberId,
+            @RequestBody ScheduleRequest request
+    ) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+        scheduleService.createSchedule(request, member);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{scheduleId}")
+    public ResponseEntity<Void> updateSchedule(
+            @PathVariable Long scheduleId,
+            @RequestBody ScheduleRequest request
+    ) {
+        scheduleService.updateSchedule(scheduleId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> deleteSchedule(@PathVariable Long scheduleId) {
+        scheduleService.deleteSchedule(scheduleId);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/{scheduleId}")
+    public ScheduleResponse getScheduleDetail(@PathVariable Long scheduleId) {
+        return scheduleService.getScheduleDetail(scheduleId);
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/calendar/dto/request/ScheduleRequest.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/dto/request/ScheduleRequest.java
@@ -1,0 +1,15 @@
+package com.hanium.mom4u.domain.calendar.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+@Getter
+
+public class ScheduleRequest {
+    private String name;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String color; // Enum 이름 (예: "RED")
+    private String healthCheck;
+}

--- a/src/main/java/com/hanium/mom4u/domain/calendar/dto/request/ScheduleRequest.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/dto/request/ScheduleRequest.java
@@ -1,15 +1,20 @@
 package com.hanium.mom4u.domain.calendar.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hanium.mom4u.domain.calendar.common.Color;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
 @Getter
-
+@Setter
 public class ScheduleRequest {
     private String name;
     private LocalDate startDate;
     private LocalDate endDate;
-    private String color; // Enum 이름 (예: "RED")
+    private Color color;
     private String healthCheck;
+
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/calendar/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/dto/response/ScheduleResponse.java
@@ -1,15 +1,18 @@
 package com.hanium.mom4u.domain.calendar.dto.response;
 
+import com.hanium.mom4u.domain.calendar.common.Color;
+import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDate;
 
 @Setter
+@Getter
 public class ScheduleResponse {
     private Long id;
     private String name;
     private LocalDate startDate;
     private LocalDate endDate;
-    private String color;
+    private Color color;
     private String healthCheck;
 }

--- a/src/main/java/com/hanium/mom4u/domain/calendar/dto/response/ScheduleResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/dto/response/ScheduleResponse.java
@@ -1,0 +1,15 @@
+package com.hanium.mom4u.domain.calendar.dto.response;
+
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Setter
+public class ScheduleResponse {
+    private Long id;
+    private String name;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String color;
+    private String healthCheck;
+}

--- a/src/main/java/com/hanium/mom4u/domain/calendar/entity/Schedule.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/entity/Schedule.java
@@ -4,9 +4,13 @@ import com.hanium.mom4u.domain.calendar.common.Color;
 import com.hanium.mom4u.domain.common.BaseEntity;
 import com.hanium.mom4u.domain.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.time.LocalDate;
-
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "calendar")
 public class Schedule extends BaseEntity {
@@ -34,4 +38,15 @@ public class Schedule extends BaseEntity {
 
     @Column(name = "health_check")
     private String healthCheck;
+
+
+    // Schedule.java (entity)
+    public void update(String name, LocalDate startDate, LocalDate endDate, Color color, String healthCheck) {
+        this.name = name;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.color = color;
+        this.healthCheck = healthCheck;
+    }
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
@@ -1,7 +1,15 @@
 package com.hanium.mom4u.domain.calendar.repository;
 
 import com.hanium.mom4u.domain.calendar.entity.Schedule;
+import com.hanium.mom4u.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    List<Schedule> findAllByMemberAndStartDateBetween(Member member, LocalDate start, LocalDate end);
+
+    List<Schedule> findAllByMemberAndStartDate(Member member, LocalDate date);
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
@@ -1,0 +1,7 @@
+package com.hanium.mom4u.domain.calendar.repository;
+
+import com.hanium.mom4u.domain.calendar.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
@@ -12,4 +12,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     List<Schedule> findAllByMemberAndStartDate(Member member, LocalDate date);
 
+    long countByMember(Member member);
+
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/calendar/service/ScheduleService.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/service/ScheduleService.java
@@ -54,6 +54,11 @@ public class ScheduleService {
 
     public void createSchedule(ScheduleRequest request, Authentication authentication) {
         Member member = getLoginMember(authentication);
+        // 일정 개수 제한 로직 추가
+        long currentCount = scheduleRepository.countByMember(member);
+        if (currentCount >= 10) {
+            throw GeneralException.of(StatusCode.SCHEDULE_LIMIT_EXCEEDED);
+        }
         Schedule schedule = Schedule.builder()
                 .name(request.getName())
                 .startDate(request.getStartDate())

--- a/src/main/java/com/hanium/mom4u/domain/calendar/service/ScheduleService.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/service/ScheduleService.java
@@ -1,0 +1,83 @@
+package com.hanium.mom4u.domain.calendar.service;
+
+import com.hanium.mom4u.domain.calendar.common.Color;
+import com.hanium.mom4u.domain.calendar.dto.request.ScheduleRequest;
+import com.hanium.mom4u.domain.calendar.dto.response.ScheduleResponse;
+import com.hanium.mom4u.domain.calendar.entity.Schedule;
+import com.hanium.mom4u.domain.calendar.repository.ScheduleRepository;
+import com.hanium.mom4u.domain.member.entity.Member;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+
+    // 전체 일정 조회
+    @Transactional(readOnly = true)
+    public List<ScheduleResponse> getAllSchedules() {
+        return scheduleRepository.findAll().stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    // 일정 저장
+    public void createSchedule(ScheduleRequest request, Member member) {
+        Schedule schedule = Schedule.builder()
+                .name(request.getName())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .color(Color.valueOf(request.getColor()))
+                .healthCheck(request.getHealthCheck())
+                .member(member)
+                .build();
+
+        scheduleRepository.save(schedule);
+    }
+
+    // 일정 수정 (scheduleId를 받아서 수정하도록 고침!)
+    public void updateSchedule(Long scheduleId, ScheduleRequest request) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("Schedule not found"));
+
+        schedule.update(
+                request.getName(),
+                request.getStartDate(),
+                request.getEndDate(),
+                Color.valueOf(request.getColor()),
+                request.getHealthCheck()
+        );
+    }
+
+    // 일정 삭제
+    public void deleteSchedule(Long scheduleId) {
+        scheduleRepository.deleteById(scheduleId);
+    }
+
+    // 일정 상세 조회
+    @Transactional(readOnly = true)
+    public ScheduleResponse getScheduleDetail(Long scheduleId) {
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("Schedule not found"));
+        return toResponse(schedule);
+    }
+
+    // 엔티티 → 응답 DTO 변환
+    private ScheduleResponse toResponse(Schedule schedule) {
+        ScheduleResponse response = new ScheduleResponse();
+        response.setId(schedule.getId());
+        response.setName(schedule.getName());
+        response.setStartDate(schedule.getStartDate());
+        response.setEndDate(schedule.getEndDate());
+        response.setColor(schedule.getColor().name());
+        response.setHealthCheck(schedule.getHealthCheck());
+        return response;
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/calendar/service/ScheduleService.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/service/ScheduleService.java
@@ -1,15 +1,19 @@
 package com.hanium.mom4u.domain.calendar.service;
 
-import com.hanium.mom4u.domain.calendar.common.Color;
 import com.hanium.mom4u.domain.calendar.dto.request.ScheduleRequest;
 import com.hanium.mom4u.domain.calendar.dto.response.ScheduleResponse;
 import com.hanium.mom4u.domain.calendar.entity.Schedule;
 import com.hanium.mom4u.domain.calendar.repository.ScheduleRepository;
 import com.hanium.mom4u.domain.member.entity.Member;
-import org.springframework.transaction.annotation.Transactional;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -20,63 +24,88 @@ public class ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
 
-    // 전체 일정 조회
-    @Transactional(readOnly = true)
-    public List<ScheduleResponse> getAllSchedules() {
-        return scheduleRepository.findAll().stream()
+    public List<ScheduleResponse> getSchedulesByMonth(Authentication authentication, int year, int month) {
+        Member member = getLoginMember(authentication);
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.with(TemporalAdjusters.lastDayOfMonth());
+
+        return scheduleRepository.findAllByMemberAndStartDateBetween(member, start, end)
+                .stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
     }
 
-    // 일정 저장
-    public void createSchedule(ScheduleRequest request, Member member) {
+    public List<ScheduleResponse> getSchedulesByDate(Authentication authentication, LocalDate date) {
+        Member member = getLoginMember(authentication);
+        return scheduleRepository.findAllByMemberAndStartDate(member, date)
+                .stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public ScheduleResponse getScheduleDetail(Long scheduleId, Authentication authentication) {
+        Member member = getLoginMember(authentication);
+        Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> GeneralException.of(StatusCode.SCHEDULE_NOT_FOUND));
+
+        validateOwnership(schedule, member);
+        return toResponse(schedule);
+    }
+
+    public void createSchedule(ScheduleRequest request, Authentication authentication) {
+        Member member = getLoginMember(authentication);
         Schedule schedule = Schedule.builder()
                 .name(request.getName())
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
-                .color(Color.valueOf(request.getColor()))
+                .color(request.getColor())
                 .healthCheck(request.getHealthCheck())
                 .member(member)
                 .build();
-
         scheduleRepository.save(schedule);
     }
 
-    // 일정 수정 (scheduleId를 받아서 수정하도록 고침!)
-    public void updateSchedule(Long scheduleId, ScheduleRequest request) {
+    public void updateSchedule(Long scheduleId, ScheduleRequest request, Authentication authentication) {
+        Member member = getLoginMember(authentication);
         Schedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new IllegalArgumentException("Schedule not found"));
+                .orElseThrow(() -> GeneralException.of(StatusCode.SCHEDULE_NOT_FOUND));
 
+        validateOwnership(schedule, member);
         schedule.update(
                 request.getName(),
                 request.getStartDate(),
                 request.getEndDate(),
-                Color.valueOf(request.getColor()),
+                request.getColor(),
                 request.getHealthCheck()
         );
     }
 
-    // 일정 삭제
-    public void deleteSchedule(Long scheduleId) {
-        scheduleRepository.deleteById(scheduleId);
-    }
-
-    // 일정 상세 조회
-    @Transactional(readOnly = true)
-    public ScheduleResponse getScheduleDetail(Long scheduleId) {
+    public void deleteSchedule(Long scheduleId, Authentication authentication) {
+        Member member = getLoginMember(authentication);
         Schedule schedule = scheduleRepository.findById(scheduleId)
-                .orElseThrow(() -> new IllegalArgumentException("Schedule not found"));
-        return toResponse(schedule);
+                .orElseThrow(() -> GeneralException.of(StatusCode.SCHEDULE_NOT_FOUND));
+
+        validateOwnership(schedule, member);
+        scheduleRepository.delete(schedule);
     }
 
-    // 엔티티 → 응답 DTO 변환
+    private void validateOwnership(Schedule schedule, Member member) {
+        if (!schedule.getMember().getId().equals(member.getId())) {
+            throw GeneralException.of(StatusCode.UNAUTHORIZED_ACCESS);
+        }
+    }
+
+    private Member getLoginMember(Authentication authentication) {
+        return (Member) authentication.getPrincipal();
+    }
+
     private ScheduleResponse toResponse(Schedule schedule) {
         ScheduleResponse response = new ScheduleResponse();
         response.setId(schedule.getId());
         response.setName(schedule.getName());
         response.setStartDate(schedule.getStartDate());
         response.setEndDate(schedule.getEndDate());
-        response.setColor(schedule.getColor().name());
+        response.setColor(schedule.getColor());
         response.setHealthCheck(schedule.getHealthCheck());
         return response;
     }

--- a/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                         .requestMatchers("/error","/v3/api-docs/**", "/swagger-ui/**",
                                 "/swagger-ui.html", "/swagger-resources/**", "/api-docs/**",
                                 "/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/schedules/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -45,6 +45,8 @@ public enum StatusCode {
 
     // schedule
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SC4001", "일정을 찾을 수 없습니다."),
+    SCHEDULE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "SC4002", "일정은 최대 10개까지만 등록할 수 있습니다."),
+
 
 
     // server

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -14,6 +14,8 @@ public enum StatusCode {
     REFRESH_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TE4004", "쿠키에 refresh token이 존재하지 않습니다."),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "TE4005", "인증된 접근 방식이 아닙니다."),
 
+
+
     //kakao login
     KAKAO_AUTH_CODE_INVALID(HttpStatus.BAD_REQUEST, "KAKAO320", "카카오 인가 코드가 이미 사용되었거나 만료되었습니다."),
     KAKAO_REDIRECT_URI_MISMATCH(HttpStatus.BAD_REQUEST, "KAKAO303", "카카오 redirect_uri가 일치하지 않습니다."),
@@ -32,6 +34,10 @@ public enum StatusCode {
 
     // member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ME4001", "회원을 조회할 수 없습니다."),
+
+    // schedule
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SC4001", "일정을 찾을 수 없습니다."),
+
 
     // server
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER5001", "서버에서 에러가 발생했습니다."),

--- a/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
@@ -1,19 +1,21 @@
 package com.hanium.mom4u.global.security.jwt;
 
 import com.hanium.mom4u.domain.member.common.Role;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
-
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.util.Collections;
 import java.util.Date;
 
 @Component
@@ -24,17 +26,16 @@ public class JwtTokenProvider {
 
     private Key key;
 
-    // access, refresh 토큰 만료 시간(초 단위)
     @Value("${spring.jwt.access.expiration}")
     private long accessTokenValidityInSeconds;
 
     @Value("${spring.jwt.refresh.expiration}")
     private long refreshTokenValidityInSeconds;
 
-    private final UserDetailsService userDetailsService;
+    private final MemberRepository memberRepository;
 
-    public JwtTokenProvider(UserDetailsService userDetailsService) {
-        this.userDetailsService = userDetailsService;
+    public JwtTokenProvider(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
     }
 
     @PostConstruct
@@ -42,14 +43,11 @@ public class JwtTokenProvider {
         this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
     }
 
-    // AccessToken 생성
     public String createAccessToken(Long memberId, Role role) {
         Claims claims = Jwts.claims().setSubject(memberId.toString());
         claims.put("role", role);
-
         Date now = new Date();
-        Date validity = new Date(now.getTime() + accessTokenValidityInSeconds);
-
+        Date validity = new Date(now.getTime() + accessTokenValidityInSeconds * 1000);
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
@@ -58,11 +56,9 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // RefreshToken 생성
     public String createRefreshToken(Long memberId) {
         Date now = new Date();
-        Date validity = new Date(now.getTime() + refreshTokenValidityInSeconds);
-
+        Date validity = new Date(now.getTime() + refreshTokenValidityInSeconds * 1000);
         return Jwts.builder()
                 .setSubject(memberId.toString())
                 .setIssuedAt(now)
@@ -71,37 +67,33 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    // 토큰에서 인증 정보 추출 (스프링 시큐리티 연동)
     public Authentication getAuthentication(String token) {
-        String memberId = getMemberId(token);
-        UserDetails userDetails = userDetailsService.loadUserByUsername(memberId);
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+        Long memberId = Long.valueOf(getMemberId(token));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
+        return new UsernamePasswordAuthenticationToken(member, "", Collections.emptyList());
     }
 
-    // 토큰에서 memberId 추출
     public String getMemberId(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build()
                 .parseClaimsJws(token).getBody().getSubject();
     }
 
-    // JWT 토큰 유효성 검증
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
             return true;
-        } catch (SecurityException | MalformedJwtException | ExpiredJwtException |
-                 UnsupportedJwtException | IllegalArgumentException e) {
-            // 로그 남기기 등
-            return false;
+        } catch (ExpiredJwtException e) {
+            throw GeneralException.of(StatusCode.INVALID_JWT_TOKEN);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw GeneralException.of(StatusCode.INVALID_JWT_TOKEN);
         }
     }
 
-    // Request Header에서 토큰 추출
+
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring(7);
-        }
-        return null;
+        return (bearerToken != null && bearerToken.startsWith("Bearer ")) ?
+                bearerToken.substring(7) : null;
     }
 }

--- a/src/main/java/com/hanium/mom4u/global/util/KakaoUtil.java
+++ b/src/main/java/com/hanium/mom4u/global/util/KakaoUtil.java
@@ -3,6 +3,7 @@ package com.hanium.mom4u.global.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hanium.mom4u.global.exception.BusinessException;
+import com.hanium.mom4u.global.exception.GeneralException;
 import com.hanium.mom4u.global.response.StatusCode;
 import com.hanium.mom4u.global.security.dto.response.KakaoTokenDto;
 import com.hanium.mom4u.global.security.dto.response.KakaoUserInfoResponseDto;
@@ -104,25 +105,25 @@ public class KakaoUtil {
         }
     }
 
-    // KakaoUtil에 mapKakaoErrorToBusinessException 메서드 추가
-    public BusinessException mapKakaoErrorToBusinessException(String errorCode) {
+    // KakaoUtil에 mapKakaoErrorToGeneralException 메서드 추가
+    public GeneralException mapKakaoErrorToBusinessException(String errorCode) {
         switch (errorCode) {
             case "KOE320":
             case "invalid_grant":
-                return new BusinessException(StatusCode.KAKAO_AUTH_CODE_INVALID);
+                return new GeneralException(StatusCode.KAKAO_AUTH_CODE_INVALID);
             case "KOE303":
             case "invalid_request":
-                return new BusinessException(StatusCode.KAKAO_REDIRECT_URI_MISMATCH);
+                return new GeneralException(StatusCode.KAKAO_REDIRECT_URI_MISMATCH);
             case "KOE101":
             case "invalid_client":
-                return new BusinessException(StatusCode.KAKAO_CLIENT_INVALID);
+                return new GeneralException(StatusCode.KAKAO_CLIENT_INVALID);
             case "KOE102":
-                return new BusinessException(StatusCode.KAKAO_INVALID_REQUEST);
+                return new GeneralException(StatusCode.KAKAO_INVALID_REQUEST);
             case "KOE006":
-                return new BusinessException(StatusCode.KAKAO_REDIRECT_URI_INVALID);
+                return new GeneralException(StatusCode.KAKAO_REDIRECT_URI_INVALID);
             default:
                 log.error("카카오 알 수 없는 에러 코드: {}", errorCode);
-                return new BusinessException(StatusCode.KAKAO_SERVER_ERROR);
+                return new GeneralException(StatusCode.KAKAO_SERVER_ERROR);
         }
     }
 


### PR DESCRIPTION
## 📌 작업 목적
사용자의 개인 일정 관리를 위한 일정 API 구현

---

## 🔨 주요 작업 내용

- 일정 월/일 조회 API 구현
- 일정 등록, 수정, 삭제, 상세 조회 API 구현

---

## 🧪 테스트 방법

- [ ] 월별/일별 조회
![image](https://github.com/user-attachments/assets/2d8aa59f-6385-4ef3-b554-d61524fa9549)

- [ ] 일정 생성/삭제/수정 시 응답
![image](https://github.com/user-attachments/assets/fcabe4a3-5d93-45ac-bf24-7cef02720554)

- [ ] 일정 생성
![image](https://github.com/user-attachments/assets/72413061-e986-4640-a6f7-f74e3f21ea75)

- [ ] 없는 일정ID에 접근할 경우
![image](https://github.com/user-attachments/assets/310f2b00-15c8-4182-a4c4-93c3d3dabd59)

- [ ] 일정이 10개를 초과한 경우
![image](https://github.com/user-attachments/assets/529ab1f0-d19a-4be8-bbf2-cd6119635eac)


---

## 📎 관련 이슈



- Closes #9 

---

## 💬 논의 또는 고민한 점

- 사용자 인증 처리를 어떤 방식으로 구현할지 고민했습니다. JWT 기반 인증에서 사용자 정보를 추출하는 방법으로는 직접 토큰 파싱 혹은 Authentication 객체 활용 두 가지가 있었는데 결론적으로 컨트롤러 메서드에서 Authentication 객체를 통해 로그인 사용자를 획득하는  구조를 채택했습니다. 더 적절한 방식이나 개선 포인트가 있다면 리뷰 부탁드립니다.


---

