### PR TITLE
Feat/baby info (#13)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,16 +41,16 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    //Webflux
+    // Webflux
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    //thymeleaf
+    // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-    //security
+    // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    //jwt
+    // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
@@ -58,10 +58,26 @@ dependencies {
     // Redis
     implementation('org.springframework.boot:spring-boot-starter-data-redis')
 
-    //swagger
+    // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    // QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def queryDslSrcDir = 'build/generated/querydsl/'
+
+sourceSets {
+    main.java.srcDirs += [queryDslSrcDir]
+}
+
+clean {
+    delete file(queryDslSrcDir)
 }

--- a/src/main/java/com/hanium/mom4u/domain/family/entity/Family.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/entity/Family.java
@@ -3,11 +3,17 @@ package com.hanium.mom4u.domain.family.entity;
 import com.hanium.mom4u.domain.common.BaseEntity;
 import com.hanium.mom4u.domain.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Entity
 @Table(name = "family")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Family extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hanium/mom4u/domain/member/common/BabyGender.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/common/BabyGender.java
@@ -1,0 +1,5 @@
+package com.hanium.mom4u.domain.member.common;
+
+public enum BabyGender {
+    MALE, FEMALE, UNKNOWN
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
@@ -1,0 +1,76 @@
+package com.hanium.mom4u.domain.member.controller;
+
+import com.hanium.mom4u.domain.member.dto.request.BabyInfoRequestDto;
+import com.hanium.mom4u.domain.member.service.BabyService;
+import com.hanium.mom4u.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/baby")
+@RequiredArgsConstructor
+public class BabyController {
+
+    private final BabyService babyService;
+
+    @Operation(summary = "태아 정보 저장 API", description = """
+            태아의 정보를 저장하는 API입니다.<br>
+            임산부가 아닐 경우 저장이 불가능합니다.
+            """)
+    @PostMapping("")
+    public ResponseEntity<CommonResponse<?>> saveBaby(
+            @RequestBody BabyInfoRequestDto requestDto) {
+
+        return ResponseEntity.ok(
+                CommonResponse.onSuccess(babyService.saveBaby(requestDto))
+        );
+    }
+
+    @Operation(summary = "태아 정보 수정 API", description = """
+            태아의 정보를 수정하는 API입니다.<br>
+            임산부가 아닐 경우 수정이 불가능합니다.
+            """)
+    @PatchMapping("/{babyId}")
+    public ResponseEntity<CommonResponse<?>> updateBaby(
+            @PathVariable("babyId") Long babyId,
+            @RequestBody BabyInfoRequestDto requestDto
+    ) {
+        return ResponseEntity.ok(
+                CommonResponse.onSuccess(babyService.updateBaby(babyId, requestDto))
+        );
+    }
+
+    @Operation(summary = "등록된 태아 정보 전체 조회 API", description = """
+            가족 구성원 간에 등록된 태아 전체를 조회합니다.<br>
+            """)
+    public ResponseEntity<CommonResponse<?>> getBabyAll() {
+        return ResponseEntity.ok(
+                CommonResponse.onSuccess(babyService.readAllBabyInfo())
+        );
+    }
+
+    @Operation(summary = "특정 태아 정보 조회하기 API", description = """
+            특정 태아의 정보만 조회하는 API입니다.<br>
+            """)
+    @GetMapping("/{babyId}")
+    public ResponseEntity<CommonResponse<?>> getBabyById(@PathVariable("babyId") Long babyId) {
+        return ResponseEntity.ok(
+                CommonResponse.onSuccess(babyService.readBabyInfo(babyId))
+        );
+    }
+
+    @Operation(summary = "특정 태아의 정보 삭제 API", description = """
+            특정 태아를 삭제하는 API입니다.<br>
+            임산부가 아닐 경우 삭제가 불가능합니다.
+            """)
+    @DeleteMapping("/{babyId}")
+    public ResponseEntity<CommonResponse<Void>> deleteBaby(@PathVariable("babyId") Long babyId) {
+
+        babyService.deleteBaby(babyId);
+        return ResponseEntity.ok(
+                CommonResponse.onSuccess()
+        );
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
@@ -4,6 +4,7 @@ import com.hanium.mom4u.domain.member.dto.request.BabyInfoRequestDto;
 import com.hanium.mom4u.domain.member.service.BabyService;
 import com.hanium.mom4u.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/v1/baby")
 @RequiredArgsConstructor
+@Tag(name = "태아 정보 API Controller", description = "태아 정보 관련 API Controller입니다.")
 public class BabyController {
 
     private final BabyService babyService;
@@ -45,6 +47,7 @@ public class BabyController {
     @Operation(summary = "등록된 태아 정보 전체 조회 API", description = """
             가족 구성원 간에 등록된 태아 전체를 조회합니다.<br>
             """)
+    @GetMapping("")
     public ResponseEntity<CommonResponse<?>> getBabyAll() {
         return ResponseEntity.ok(
                 CommonResponse.onSuccess(babyService.readAllBabyInfo())

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/request/BabyInfoRequestDto.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/request/BabyInfoRequestDto.java
@@ -1,0 +1,17 @@
+package com.hanium.mom4u.domain.member.dto.request;
+
+import com.hanium.mom4u.domain.member.common.BabyGender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class BabyInfoRequestDto {
+    private String name;
+    @Schema(description = "출산 예정일")
+    private LocalDate pregnantDate;
+    private BabyGender babyGender;
+    @Schema(description = "주차 수")
+    private int weekLevel;
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/request/BabyInfoRequestDto.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/request/BabyInfoRequestDto.java
@@ -7,10 +7,15 @@ import lombok.Getter;
 import java.time.LocalDate;
 
 @Getter
+@Schema(description = "태아 정보 요청 DTO")
 public class BabyInfoRequestDto {
+    @Schema(description = "태아 ID")
+    private long babyId;
+    @Schema(description = "태아 이름")
     private String name;
     @Schema(description = "출산 예정일")
     private LocalDate pregnantDate;
+    @Schema(description = "태아 성별")
     private BabyGender babyGender;
     @Schema(description = "주차 수")
     private int weekLevel;

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/response/BabyInfoResponseDto.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/response/BabyInfoResponseDto.java
@@ -13,11 +13,16 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "태아 정보 반환 DTO")
 public class BabyInfoResponseDto {
 
+    @Schema(description = "태아 ID")
+    private long babyId;
+    @Schema(description = "태아 이름")
     private String name;
     @Schema(description = "출산 예정일")
     private LocalDate pregnantDate;
+    @Schema(description = "태아 성별")
     private BabyGender babyGender;
     @Schema(description = "주차 수")
     private int weekLevel;

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/response/BabyInfoResponseDto.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/response/BabyInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.hanium.mom4u.domain.member.dto.response;
+
+import com.hanium.mom4u.domain.member.common.BabyGender;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class BabyInfoResponseDto {
+
+    private String name;
+    @Schema(description = "출산 예정일")
+    private LocalDate pregnantDate;
+    private BabyGender babyGender;
+    @Schema(description = "주차 수")
+    private int weekLevel;
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/entity/Baby.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/entity/Baby.java
@@ -49,4 +49,22 @@ public class Baby extends BaseEntity {
     @Setter
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public Baby updateInfo(BabyInfoRequestDto requestDto) {
+        if (requestDto.getName() != null && !requestDto.getName().isEmpty()) {
+            this.name = requestDto.getName();
+        }
+        if (requestDto.getPregnantDate() != null) {
+            this.pregnantDate = requestDto.getPregnantDate();
+        }
+        if (requestDto.getBabyGender() != null) {
+            this.gender = requestDto.getBabyGender();
+        }
+
+        if (requestDto.getWeekLevel() > 0) {
+            this.weekLevel = requestDto.getWeekLevel();
+        }
+
+        return this;
+    }
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/entity/Baby.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/entity/Baby.java
@@ -1,14 +1,19 @@
 package com.hanium.mom4u.domain.member.entity;
 
 import com.hanium.mom4u.domain.common.BaseEntity;
+import com.hanium.mom4u.domain.member.common.BabyGender;
+import com.hanium.mom4u.domain.member.dto.request.BabyInfoRequestDto;
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDate;
 
 @Entity
 @Table(name = "baby")
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Baby extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,8 +26,8 @@ public class Baby extends BaseEntity {
     @Column(name = "pregnant_date")
     private LocalDate pregnantDate;
 
-    @Column(name = "month_level")
-    private int monthLevel;
+    @Column(name = "week_level")
+    private int weekLevel;
 
     @Column(name = "due_date")
     private LocalDate dueDate;
@@ -30,8 +35,9 @@ public class Baby extends BaseEntity {
     @Column(name = "is_ended")
     private boolean isEnded;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "gender")
-    private String gender;
+    private BabyGender gender;
 
     @Column(name = "name")
     private String name;
@@ -40,6 +46,7 @@ public class Baby extends BaseEntity {
     private int birthYear;
 
     @ManyToOne
+    @Setter
     @JoinColumn(name = "member_id")
     private Member member;
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/repository/BabyRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/repository/BabyRepository.java
@@ -1,0 +1,9 @@
+package com.hanium.mom4u.domain.member.repository;
+
+import com.hanium.mom4u.domain.member.entity.Baby;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BabyRepository extends JpaRepository<Baby,Long> {
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
@@ -1,13 +1,15 @@
 package com.hanium.mom4u.domain.member.repository;
 
+import com.hanium.mom4u.domain.family.entity.Family;
 import com.hanium.mom4u.domain.member.common.SocialType;
 import com.hanium.mom4u.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmailAndSocialType(String email, SocialType socialType);
-    Optional<Member> findByEmail(String email);
 
+    List<Member> findByFamily(Family family);
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/service/BabyService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/BabyService.java
@@ -1,0 +1,155 @@
+package com.hanium.mom4u.domain.member.service;
+
+import com.hanium.mom4u.domain.member.dto.request.BabyInfoRequestDto;
+import com.hanium.mom4u.domain.member.dto.response.BabyInfoResponseDto;
+import com.hanium.mom4u.domain.member.entity.Baby;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.BabyRepository;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import com.hanium.mom4u.global.exception.BusinessException;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
+import com.hanium.mom4u.global.security.jwt.AuthenticatedProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BabyService {
+
+    private final AuthenticatedProvider authenticatedProvider;
+
+    private final BabyRepository babyRepository;
+    private final MemberRepository memberRepository;
+
+
+    // 태아 정보 등록하기
+    @Transactional
+    public BabyInfoResponseDto saveBaby(BabyInfoRequestDto requestDto) {
+
+        Member member = authenticatedProvider.getCurrentMember();
+        log.info("member 조회 완료: {}", member.getId());
+
+        // 임산부인 경우에만 태아 정보 등록 가능
+        if (member.isPregnant()) {
+            log.info("임산부인 사용자의 태아 등록 시작...");
+            Baby baby = Baby.builder()
+                    .name(requestDto.getName())
+                    .gender(requestDto.getBabyGender())
+                    .pregnantDate(requestDto.getPregnantDate())
+                    .weekLevel(requestDto.getWeekLevel())
+                    .build();
+            baby.setMember(member);
+            babyRepository.save(baby);
+
+            return BabyInfoResponseDto.builder()
+                    .name(baby.getName())
+                    .pregnantDate(baby.getPregnantDate())
+                    .babyGender(baby.getGender())
+                    .weekLevel(baby.getWeekLevel())
+                    .build();
+        } else {
+            log.warn("임산부가 아닙니다.");
+            throw BusinessException.of(StatusCode.ONLY_PREGNANT);
+        }
+    }
+
+    // 특정 태아 정보 조회하기
+    @Transactional(readOnly = true)
+    public BabyInfoResponseDto readBabyInfo(Long babyId) {
+        Member member = authenticatedProvider.getCurrentMember();
+        log.info("member 조회 완료: {}", member.getId());
+
+        Baby baby = babyRepository.findById(babyId)
+                .orElseThrow(() -> GeneralException.of(StatusCode.BABY_NOT_FOUND));
+
+        return BabyInfoResponseDto.builder()
+                .name(baby.getName())
+                .pregnantDate(baby.getPregnantDate())
+                .babyGender(baby.getGender())
+                .weekLevel(baby.getWeekLevel())
+                .build();
+    }
+
+    // 등록된 태아 전체 조회하기
+    @Transactional(readOnly = true)
+    public List<BabyInfoResponseDto> readAllBabyInfo() {
+        Member member = authenticatedProvider.getCurrentMember();
+        log.info("member 조회 완료: {}", member.getId());
+
+        if (member.isPregnant()) {
+            return member.getBabyList()
+                    .stream()
+                    .map(baby ->
+                        BabyInfoResponseDto.builder()
+                                .name(baby.getName())
+                                .pregnantDate(baby.getPregnantDate())
+                                .babyGender(baby.getGender())
+                                .weekLevel(baby.getWeekLevel())
+                                .build())
+                    .toList();
+        } else {
+
+            // 가족 구성원 등록 우선 필요
+            if (member.getFamily() != null) {
+                throw BusinessException.of(StatusCode.UNREGISTERED_FAMILY);
+            }
+
+            // 임산부가 아닐 때의 태아 조회
+            List<Member> familyMembers = memberRepository.findByFamily(member.getFamily());
+            return familyMembers.stream()
+                    .filter(Member::isPregnant)
+                    .flatMap(pregnantMember -> pregnantMember.getBabyList().stream())
+                    .map(baby -> BabyInfoResponseDto.builder()
+                            .name(baby.getName())
+                            .pregnantDate(baby.getPregnantDate())
+                            .babyGender(baby.getGender())
+                            .weekLevel(baby.getWeekLevel())
+                            .build())
+                    .toList();
+        }
+    }
+
+//    // 태아 정보 수정하기
+    @Transactional
+    public BabyInfoResponseDto updateBaby(Long babyId, BabyInfoRequestDto requestDto) {
+
+        Member member = authenticatedProvider.getCurrentMember();
+        log.info("member 조회 완료: {}", member.getId());
+
+        // 임산부에게만 태아 정보 수정 권한 부여
+        if (member.isPregnant()) {
+            Baby baby = babyRepository.findById(babyId)
+                    .map(b -> b.updateInfo(requestDto))
+                    .orElseThrow(() -> GeneralException.of(StatusCode.BABY_NOT_FOUND));
+
+            return BabyInfoResponseDto.builder()
+                    .name(baby.getName())
+                    .pregnantDate(baby.getPregnantDate())
+                    .babyGender(baby.getGender())
+                    .weekLevel(baby.getWeekLevel())
+                    .build();
+        } else {
+            throw BusinessException.of(StatusCode.ONLY_PREGNANT);
+        }
+    }
+
+    // 태아 정보 삭제하기
+    @Transactional
+    public void deleteBaby(Long babyId) {
+        Member member = authenticatedProvider.getCurrentMember();
+        log.info("member 조회 완료: {}", member.getId());
+
+        // 임산부에게만 태아 정보 수정 권한 부여
+        if (member.isPregnant()) {
+            babyRepository.deleteById(babyId);
+        } else {
+            throw BusinessException.of(StatusCode.ONLY_PREGNANT);
+        }
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/service/BabyService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/BabyService.java
@@ -46,8 +46,10 @@ public class BabyService {
                     .build();
             baby.setMember(member);
             babyRepository.save(baby);
+            log.info("Baby ID {} 저장 성공...", baby.getId());
 
             return BabyInfoResponseDto.builder()
+                    .babyId(baby.getId())
                     .name(baby.getName())
                     .pregnantDate(baby.getPregnantDate())
                     .babyGender(baby.getGender())
@@ -69,6 +71,7 @@ public class BabyService {
                 .orElseThrow(() -> GeneralException.of(StatusCode.BABY_NOT_FOUND));
 
         return BabyInfoResponseDto.builder()
+                .babyId(baby.getId())
                 .name(baby.getName())
                 .pregnantDate(baby.getPregnantDate())
                 .babyGender(baby.getGender())
@@ -87,6 +90,7 @@ public class BabyService {
                     .stream()
                     .map(baby ->
                         BabyInfoResponseDto.builder()
+                                .babyId(baby.getId())
                                 .name(baby.getName())
                                 .pregnantDate(baby.getPregnantDate())
                                 .babyGender(baby.getGender())
@@ -96,16 +100,18 @@ public class BabyService {
         } else {
 
             // 가족 구성원 등록 우선 필요
-            if (member.getFamily() != null) {
+            if (member.getFamily().getId() == null) {
                 throw BusinessException.of(StatusCode.UNREGISTERED_FAMILY);
             }
 
             // 임산부가 아닐 때의 태아 조회
             List<Member> familyMembers = memberRepository.findByFamily(member.getFamily());
+            log.info("{} family ID에 등록된 태아 조회...", member.getFamily().getId());
             return familyMembers.stream()
                     .filter(Member::isPregnant)
                     .flatMap(pregnantMember -> pregnantMember.getBabyList().stream())
                     .map(baby -> BabyInfoResponseDto.builder()
+                            .babyId(baby.getId())
                             .name(baby.getName())
                             .pregnantDate(baby.getPregnantDate())
                             .babyGender(baby.getGender())
@@ -129,6 +135,7 @@ public class BabyService {
                     .orElseThrow(() -> GeneralException.of(StatusCode.BABY_NOT_FOUND));
 
             return BabyInfoResponseDto.builder()
+                    .babyId(baby.getId())
                     .name(baby.getName())
                     .pregnantDate(baby.getPregnantDate())
                     .babyGender(baby.getGender())

--- a/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
@@ -1,8 +1,12 @@
 package com.hanium.mom4u.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanium.mom4u.global.response.ErrorResponse;
+import com.hanium.mom4u.global.response.StatusCode;
 import com.hanium.mom4u.global.security.jwt.JwtAuthenticationFilter;
 import com.hanium.mom4u.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -19,6 +23,7 @@ import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
+@Slf4j
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider; // JwtTokenProvider 주입
@@ -36,12 +41,27 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/error","/v3/api-docs/**", "/swagger-ui/**",
-                                "/swagger-ui.html", "/swagger-resources/**", "/api-docs/**",
+                        .requestMatchers("/test/**","/v3/api-docs/**", "/swagger-ui/**",
+                                "/swagger-resources/**", "/api-docs/**",
                                 "/api/v1/auth/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling(ex -> ex
+                        .accessDeniedHandler((request, response, accessDeniedException) -> {
+                            log.error("Access denied : {}", accessDeniedException);
+
+                            ErrorResponse errorResponse = ErrorResponse.builder()
+                                    .httpStatus(StatusCode.UNAUTHORIZED_ACCESS.getHttpStatus())
+                                    .code(StatusCode.UNAUTHORIZED_ACCESS.getCode())
+                                    .message(StatusCode.UNAUTHORIZED_ACCESS.getDescription())
+                                    .build();
+
+                            response.setStatus(StatusCode.UNAUTHORIZED_ACCESS.getHttpStatus().value());
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+                        })
+                )
                 .build();
     }
 

--- a/src/main/java/com/hanium/mom4u/global/config/SwaggerConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/SwaggerConfig.java
@@ -3,6 +3,7 @@ package com.hanium.mom4u.global.config;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +22,10 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("JWT", jwtScheme))
-                .info(new Info().title("Dear Belly").version("v1.0"));
+                .addSecurityItem(new SecurityRequirement().addList("JWT"))
+                .info(new Info()
+                        .title("Dear Belly")
+                        .version("v1.0")
+                        .description("Dear Belly 백엔드 API 문서입니다."));
     }
-
 }

--- a/src/main/java/com/hanium/mom4u/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/hanium/mom4u/global/exception/GlobalExceptionHandler.java
@@ -5,10 +5,13 @@ import com.hanium.mom4u.global.response.ErrorResponse;
 import com.hanium.mom4u.global.response.StatusCode;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.nio.file.AccessDeniedException;
 
 @Slf4j
 @RestControllerAdvice
@@ -23,7 +26,7 @@ public class GlobalExceptionHandler {
 
     // BussinessException(성공 응답(200)이되, 에러 메세지를 담아서 반환)
     @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<CommonResponse> customException(BusinessException e, HttpServletRequest request) {
+    protected ResponseEntity<CommonResponse> businessException(BusinessException e, HttpServletRequest request) {
         logError(e, request);
         return ResponseEntity.ok(CommonResponse.withMessage(e.getStatusCode()));
     }

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -37,9 +37,15 @@ public enum StatusCode {
     GOOGLE_PROFILE_FAILED(HttpStatus.BAD_REQUEST, "GE4003", "구글 프로필 정보를 읽어들이는 데에 실패하였습니다."),
     GOOGLE_PARSE_ERROR(HttpStatus.BAD_REQUEST, "GE4004", "구글로부터 얻은 정보를 파싱하는 데에 실패하였습니다."),
 
+    // baby
+    ONLY_PREGNANT(HttpStatus.BAD_REQUEST, "BE4001", "임산부가 아니라면 태아 정보를 등록할 수 없습니다."),
+    BABY_NOT_FOUND(HttpStatus.NOT_FOUND, "BE4002", "해당 태아의 정보를 찾을 수 없습니다."),
 
     // member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ME4001", "회원을 조회할 수 없습니다."),
+
+    // family
+    UNREGISTERED_FAMILY(HttpStatus.NOT_FOUND, "FE4001", "가족 등록 내역이 없습니다."),
 
     // server
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER5001", "서버에서 에러가 발생했습니다."),

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -47,7 +47,12 @@ public enum StatusCode {
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SC4001", "일정을 찾을 수 없습니다."),
     SCHEDULE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "SC4002", "일정은 최대 10개까지만 등록할 수 있습니다."),
 
+    // baby
+    ONLY_PREGNANT(HttpStatus.UNAUTHORIZED, "BE4001", "임산부에게 주어진 권한입니다."),
+    BABY_NOT_FOUND(HttpStatus.BAD_REQUEST, "BE4002", "해당 태아를 조회할 수 없습니다."),
 
+    // family
+    UNREGISTERED_FAMILY(HttpStatus.NOT_FOUND, "FE4001", "가족 정보가 등록되지 않았습니다."),
 
     // server
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER5001", "서버에서 에러가 발생했습니다."),

--- a/src/main/java/com/hanium/mom4u/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hanium/mom4u/global/security/jwt/JwtAuthenticationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/swagger-ui/")||
                 path.startsWith("/v3/api-docs") ||
                 path.startsWith("/swagger-resources/")||
-                path.startsWith("/error");
+                path.startsWith("/test");
         System.out.println("Should not filter: " + shouldNotFilter);
 
         return shouldNotFilter;

--- a/src/main/java/com/hanium/mom4u/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hanium/mom4u/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,10 +1,15 @@
 package com.hanium.mom4u.global.security.jwt;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.ErrorResponse;
+import com.hanium.mom4u.global.response.StatusCode;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -28,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/swagger-ui/")||
                 path.startsWith("/v3/api-docs") ||
                 path.startsWith("/swagger-resources/")||
-                path.startsWith("/error");
+                path.startsWith("/test");
         System.out.println("Should not filter: " + shouldNotFilter);
 
         return shouldNotFilter;

--- a/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,6 +18,7 @@ import java.security.Key;
 import java.util.Date;
 
 @Component
+@Slf4j
 public class JwtTokenProvider {
 
     @Value("${spring.jwt.secret}")
@@ -91,7 +93,7 @@ public class JwtTokenProvider {
             return true;
         } catch (SecurityException | MalformedJwtException | ExpiredJwtException |
                  UnsupportedJwtException | IllegalArgumentException e) {
-            // 로그 남기기 등
+            log.error("Invalid Token... {}", e);
             return false;
         }
     }

--- a/src/main/java/com/hanium/mom4u/global/test/TestController.java
+++ b/src/main/java/com/hanium/mom4u/global/test/TestController.java
@@ -4,6 +4,7 @@ import com.hanium.mom4u.global.exception.BusinessException;
 import com.hanium.mom4u.global.exception.GeneralException;
 import com.hanium.mom4u.global.response.CommonResponse;
 import com.hanium.mom4u.global.response.StatusCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/test")
+@Slf4j
 public class TestController {
 
     @GetMapping("/success/data")


### PR DESCRIPTION
## 📌 작업 목적
태아 정보 관련 기능 구현

---

## 🔨 주요 작업 내용
- 기본적인 태아 정보 등록, 수정, 조회, 삭제 API 구현
- 임산부가 아닌 경우 등록 및 수정 권한 불가
- 동일한 가족 그룹 간의 태아 정보 공유

---

## 📷 스크린샷
- [x] 태아 정보 저장(임산부일 경우 / 임산부 아닐 경우)
<img src="https://github.com/user-attachments/assets/4cbf1606-5c53-447c-81cf-254c70e30b49" width="55%"><img src="https://github.com/user-attachments/assets/61847a3d-0c96-4028-ad95-47dce2a601a0" width="55%">

- [x] 가족 등록이 안되어있을 경우 / 가족 등록 후의 등록 태아 조회
<img src="https://github.com/user-attachments/assets/95259a72-06ba-4ed2-b137-cbb49004de41" width="60%"><img src="https://github.com/user-attachments/assets/bbd02e89-5e15-42ea-870b-902ac48ef38b" width="60%">

- [x] 그 외의 기본적인 CRUD 구현 완료
<img src="https://github.com/user-attachments/assets/6aa57460-2c38-4e95-80f0-3b78609cc6dd" width="50%"><img src="https://github.com/user-attachments/assets/1fea9603-deb0-4854-87e4-2ceff397b7d2" width="50%">
<img src="https://github.com/user-attachments/assets/b09111db-5693-4ba9-aa1c-f5cc8c8b2c0d" width="60%">


---

## 📄 논의해볼 내용
- UserDetails를 상속받아 Member 관련 custom Class를 따로 생성하여 관리하는 것도 좋을 것 같습니다 ! 😄 
- 로직 구현 도중 QueryDSL 사용을 의도하고 추가했었으나, 사용하지 않았고 다음 로직 때 사용 혹은 삭제하겠습니다!