### PR TITLE
Feat/signup family code 14 (#14)

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/controller/FamilyController.java
@@ -1,0 +1,66 @@
+package com.hanium.mom4u.domain.family.controller;
+
+import com.hanium.mom4u.domain.family.dto.request.FamilyCodeRequest;
+import com.hanium.mom4u.domain.family.service.FamilyService;
+import com.hanium.mom4u.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "가족 코드 API", description = "가족 코드 생성/참여/조회/수정 관련 API입니다.")
+public class FamilyController {
+    private final FamilyService familyService;
+
+    @Operation(summary = "가족 코드 생성 API(마이페이지)", description = """
+            임산부만 호출 가능한 API입니다.<br>
+            랜덤한 8자리 코드가 자동으로 생성되며, 기존 가족이 없을 경우 새 가족이 생성됩니다.<br>
+            기존 가족이 있을 경우에는 가족 코드만 갱신됩니다.
+            """)
+    @PostMapping("/api/v1/family-code")
+    public ResponseEntity<CommonResponse> generateFamilyCode() {
+        String code = familyService.createFamilyCode(); // 파라미터 없음
+        return ResponseEntity.ok(CommonResponse.onSuccess(code));
+    }
+
+    @Operation(summary = "가족 참여 API", description = """
+            보호자 또는 가족 구성원이 가족 코드를 입력해 가족에 참여하는 API입니다.<br>
+            이미 가족에 소속된 사용자는 참여할 수 없습니다.<br>
+            유효하지 않거나 만료된 코드 입력 시 예외가 발생합니다.
+            """)
+    @PostMapping("api/v1/family-code/join")
+    public ResponseEntity<CommonResponse> joinFamily(@RequestBody FamilyCodeRequest request){
+        familyService.joinFamily(request.getCode());
+        return ResponseEntity.ok(CommonResponse.onSuccess("가족 참여 완료"));
+    }
+
+    @Operation(summary = "가족 코드 조회 API", description = """
+            현재 로그인한 사용자의 가족 코드 정보를 조회하는 API입니다.<br>
+            가족에 소속되어 있지 않으면 예외가 발생합니다.
+            """)
+    @GetMapping("/api/v1/family-code")
+    public ResponseEntity<CommonResponse> getFamilyCode() {
+        String code = familyService.getFamilyCode();
+        return ResponseEntity.ok(CommonResponse.onSuccess(code));
+    }
+
+    @Operation(summary = "가족 코드 재발급 API", description = """
+            임산부만 호출 가능한 API입니다.<br>
+            기존 코드가 만료되고 새로 랜덤한 8자리 코드로 재발급됩니다.<br>
+            이전 코드로는 가족 참여가 불가능합니다.
+            """)
+    @PatchMapping("/api/v1/family-code")
+    public ResponseEntity<CommonResponse> updateFamilyCode() {
+        String updatedCode = familyService.createNewFamilyCode();  // 새 코드 자동 생성
+        return ResponseEntity.ok(CommonResponse.onSuccess(updatedCode));
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/hanium/mom4u/domain/family/dto/request/FamilyCodeRequest.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/dto/request/FamilyCodeRequest.java
@@ -1,0 +1,8 @@
+package com.hanium.mom4u.domain.family.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class FamilyCodeRequest {
+    private String code;
+}

--- a/src/main/java/com/hanium/mom4u/domain/family/entity/Family.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/entity/Family.java
@@ -6,11 +6,13 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Entity
 @Table(name = "family")
+@Setter
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/hanium/mom4u/domain/family/repository/FamilyRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/repository/FamilyRepository.java
@@ -1,0 +1,13 @@
+package com.hanium.mom4u.domain.family.repository;
+
+import com.hanium.mom4u.domain.family.entity.Family;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FamilyRepository extends JpaRepository<Family, Long> {
+
+    Optional<Family> findByCode(String code);
+
+    boolean existsByCode(String code);
+}

--- a/src/main/java/com/hanium/mom4u/domain/family/service/FamilyService.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/service/FamilyService.java
@@ -60,19 +60,23 @@ public class FamilyService {
     public void joinFamily(String inputCode) {
         Member member = authenticatedProvider.getCurrentMember();
 
-
-        if (member.getFamily() != null) {
-            throw BusinessException.of(StatusCode.ALREADY_HAS_FAMILY);
-        }
-
-
-        Family family = familyRepository.findByCode(inputCode)
+        // 입력된 코드에 해당하는 가족이 있는지 조회
+        Family familyByInputCode = familyRepository.findByCode(inputCode)
                 .orElseThrow(() -> GeneralException.of(StatusCode.UNREGISTERED_FAMILY));
 
+        // 현재 사용자의 가족이 있는 경우
+        Family currentFamily = member.getFamily();
 
-        member.setFamily(family);
+        // 사용자의 현재 가족이 입력된 코드와 일치하지 않으면 → 유효하지 않은 코드
+        if (currentFamily != null && !currentFamily.getCode().equals(inputCode)) {
+            throw GeneralException.of(StatusCode.UNREGISTERED_FAMILY);  // or 새로운 StatusCode.INVALID_FAMILY_CODE
+        }
+
+        // 정상적인 경우 → 가족 연결
+        member.setFamily(familyByInputCode);
         memberRepository.save(member);
     }
+
 
     @Transactional
     public String createNewFamilyCode() {

--- a/src/main/java/com/hanium/mom4u/domain/family/service/FamilyService.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/service/FamilyService.java
@@ -1,0 +1,106 @@
+package com.hanium.mom4u.domain.family.service;
+
+import com.hanium.mom4u.domain.family.entity.Family;
+import com.hanium.mom4u.domain.family.repository.FamilyRepository;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import com.hanium.mom4u.global.exception.BusinessException;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
+import com.hanium.mom4u.global.security.jwt.AuthenticatedProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class FamilyService {
+
+    private final AuthenticatedProvider authenticatedProvider;
+    private final FamilyRepository familyRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public String createFamilyCode() {
+        Member member = authenticatedProvider.getCurrentMember();
+
+        if (!member.isPregnant()) {
+            throw BusinessException.of(StatusCode.ONLY_PREGNANT);
+        }
+
+        // 랜덤 코드 생성 및 중복 방지
+        String code;
+        do {
+            code = UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        } while (familyRepository.existsByCode(code));
+
+        // 기존 가족이 없으면 새로 생성
+        if (member.getFamily() == null) {
+            Family family = new Family();
+            family.setCode(code);
+            familyRepository.save(family);
+
+            member.setFamily(family);
+            memberRepository.save(member);
+            return code;
+        }
+
+        // 기존 가족이 있으면 코드만 갱신
+        Family family = member.getFamily();
+        family.setCode(code);
+        familyRepository.save(family);
+
+        return code;
+    }
+
+
+    @Transactional
+    public void joinFamily(String inputCode) {
+        Member member = authenticatedProvider.getCurrentMember();
+
+
+        if (member.getFamily() != null) {
+            throw BusinessException.of(StatusCode.ALREADY_HAS_FAMILY);
+        }
+
+
+        Family family = familyRepository.findByCode(inputCode)
+                .orElseThrow(() -> GeneralException.of(StatusCode.UNREGISTERED_FAMILY));
+
+
+        member.setFamily(family);
+        memberRepository.save(member);
+    }
+
+    @Transactional
+    public String createNewFamilyCode() {
+        Member currentUser = authenticatedProvider.getCurrentMember(); // 현재 로그인 사용자
+
+        if (!currentUser.isPregnant()) {
+            throw new BusinessException(StatusCode.ONLY_PREGNANT);
+        }
+
+        Family family = currentUser.getFamily();
+        String newCode = UUID.randomUUID().toString().substring(0, 8); // 8자리만 추출
+
+        family.setCode(newCode);
+        familyRepository.save(family);
+
+        return newCode;
+    }
+
+
+    @Transactional(readOnly = true)
+    public String getFamilyCode() {
+        Member member = authenticatedProvider.getCurrentMember();
+
+        if (member.getFamily() == null) {
+            throw BusinessException.of(StatusCode.UNREGISTERED_FAMILY);
+        }
+
+        return member.getFamily().getCode();
+    }
+
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
@@ -1,0 +1,50 @@
+package com.hanium.mom4u.domain.member.controller;
+
+import com.hanium.mom4u.domain.member.service.MemberService;
+import com.hanium.mom4u.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+@Tag(name = "회원 프로필 API", description = "닉네임/프로필 사진 변경 API")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "회원가입: 개인정보 입력", description = "회원정보를 입력합니다.")
+    @PatchMapping("/profile")
+    public ResponseEntity<CommonResponse<Void>> updateProfile(
+            @RequestParam("nickname") String nickname,
+            @RequestParam(value = "imgFile", required = false) MultipartFile imgFile,
+            @RequestParam("isPregnant") Boolean isPregnant,
+            @RequestParam(value = "dueDate", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate dueDate,
+            @RequestParam(value = "pre_pregnant", required = false) Boolean prePregnant,
+            @RequestParam("gender") String gender,
+            @RequestParam("birth")
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate birth
+    )
+{
+        memberService.updateProfile(nickname,imgFile,isPregnant,dueDate,prePregnant,gender,birth);
+        return ResponseEntity.ok(CommonResponse.onSuccess());
+    }
+
+
+    @Operation(summary = "회원정보 조회", description = "현재 로그인한 회원 정보를 조회합니다.")
+    @GetMapping("/profile")
+    public ResponseEntity<CommonResponse> getMyProfile() {
+        return ResponseEntity.ok(CommonResponse.onSuccess(memberService.getMyProfile()));
+    }
+
+
+}
+

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,19 @@
+package com.hanium.mom4u.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class MemberInfoResponse {
+    private String nickname;
+    private String imgUrl;
+    private Boolean isPregnant;
+    private LocalDate dueDate;
+    private Boolean prePregnant;
+    private String gender;
+    private LocalDate birthDate;
+}
+

--- a/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
@@ -44,8 +44,23 @@ public class Member extends BaseEntity {
     @Column(name = "gender")
     private String gender;
 
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
     @Column(name = "is_pregnant")
     private boolean isPregnant;
+
+    @Column(name = "pregnant_week")
+    private int pregnantWeek;
+
+    @Column(name = "due_date")
+    private LocalDate dueDate;
+
+    @Column(name = "pre_pregnant")
+    private Boolean prePregnant;
+
+    @Column(name = "img_url")
+    private String imgUrl;
 
     @Column(name = "is_inactive")
     private boolean isInactive;
@@ -53,11 +68,6 @@ public class Member extends BaseEntity {
     @Column(name = "inactive_date")
     private LocalDate inactiveDate;
 
-    @Column(name = "pregnant_week")
-    private int pregnantWeek;
-
-    @Column(name = "img_url")
-    private String imgUrl;
 
     @ManyToOne
     @JoinColumn(name = "family_id")

--- a/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
@@ -19,7 +19,7 @@ public class FileStorageService {
 
     public String save(MultipartFile file){;
         if(file==null || file.isEmpty()){
-            throw new IllegalArgumentException("파일이 비어있습니다.");
+            throw GeneralException.of(StatusCode.FILE_EMPTY);
         }try {
             // 업로드 폴더가 없으면 생성
             File dir = new File(UPLOAD_DIR);

--- a/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
@@ -1,0 +1,45 @@
+package com.hanium.mom4u.domain.member.service;
+
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+@Transactional
+public class FileStorageService {
+    private static final String UPLOAD_DIR="uploads";
+
+    public String save(MultipartFile file){;
+        if(file==null || file.isEmpty()){
+            throw new IllegalArgumentException("파일이 비어있습니다.");
+        }try {
+            // 업로드 폴더가 없으면 생성
+            File dir = new File(UPLOAD_DIR);
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
+            // 파일명 중복 방지 (타임스탬프 등)
+            String originalFilename = file.getOriginalFilename();
+            String filename = System.currentTimeMillis() + "_" + originalFilename;
+            Path filePath = Paths.get(UPLOAD_DIR, filename);
+
+            // 파일 저장
+            Files.copy(file.getInputStream(), filePath);
+
+            // 반환: 웹에서 접근 가능한 경로
+            return "/uploads/" + filename;
+        } catch (IOException e) {
+            throw GeneralException.of(StatusCode.FILE_SAVE_FAILED);
+        }
+
+    }
+    }
+

--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -1,0 +1,68 @@
+package com.hanium.mom4u.domain.member.service;
+
+import com.hanium.mom4u.domain.member.dto.response.MemberInfoResponse;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
+import com.hanium.mom4u.global.security.jwt.AuthenticatedProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+    private final AuthenticatedProvider authenticatedProvider;
+    private final FileStorageService fileStorageService;
+    private final MemberRepository memberRepository;
+    private static final String DEFAULT_PROFILE_IMG_URL = "/images/default-profile.png";
+
+    public void updateProfile(String nickname, MultipartFile imgFile,Boolean isPregnant,
+                              LocalDate dueDate, Boolean prePregnant, String gender, LocalDate birth){
+        Member member = authenticatedProvider.getCurrentMember();
+        member = memberRepository.findById(member.getId())
+                .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
+
+        member.setNickname(nickname);
+
+
+        if(imgFile != null && !imgFile.isEmpty()){
+            String imgUrl = fileStorageService.save(imgFile);
+            member.setImgUrl(imgUrl);
+        } else {
+            member.setImgUrl(DEFAULT_PROFILE_IMG_URL);
+        }
+
+        member.setPregnant(isPregnant);
+        member.setDueDate(dueDate); // Member 엔티티에 dueDate 필드 추가 필요
+        member.setPrePregnant(prePregnant); // Member 엔티티에 prePregnant 필드 추가 필요
+        member.setGender(gender);
+        member.setBirthDate(birth); // Member 엔티티에 birth 필드 추가 필요
+        memberRepository.save(member);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberInfoResponse getMyProfile() {
+        Member member = authenticatedProvider.getCurrentMember();
+        member = memberRepository.findById(member.getId())
+                .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
+
+        return new MemberInfoResponse(
+                member.getNickname(),
+                member.getImgUrl(),
+                member.isPregnant(),
+                member.getDueDate(),
+                member.getPrePregnant(),
+                member.getGender(),
+                member.getBirthDate()
+        );
+    }
+
+}
+

--- a/src/main/java/com/hanium/mom4u/external/WebConfig.java
+++ b/src/main/java/com/hanium/mom4u/external/WebConfig.java
@@ -1,0 +1,17 @@
+package com.hanium.mom4u.external;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String uploadPath = Paths.get("uploads").toAbsolutePath().toUri().toString();
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations(uploadPath);  // "file:" 포함된 URI로 자동 변환됨
+    }
+}

--- a/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/test/**","/v3/api-docs/**", "/swagger-ui/**",
-                                "/swagger-resources/**", "/api-docs/**",
+                                "/swagger-resources/**", "/api-docs/**","/uploads/**",
                                 "/api/v1/auth/**").permitAll()
                         .requestMatchers("/api/v1/schedules/**","api/v1/family-code/**").authenticated()
                         .anyRequest().authenticated()

--- a/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         .requestMatchers("/test/**","/v3/api-docs/**", "/swagger-ui/**",
                                 "/swagger-resources/**", "/api-docs/**",
                                 "/api/v1/auth/**").permitAll()
-                        .requestMatchers("/api/v1/schedules/**").authenticated()
+                        .requestMatchers("/api/v1/schedules/**","api/v1/family-code/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -55,7 +55,7 @@ public enum StatusCode {
     BABY_NOT_FOUND(HttpStatus.BAD_REQUEST, "BE4002", "해당 태아를 조회할 수 없습니다."),
 
     // family
-    UNREGISTERED_FAMILY(HttpStatus.NOT_FOUND, "FE4001", "가족 정보가 등록되지 않았습니다."),
+    UNREGISTERED_FAMILY(HttpStatus.NOT_FOUND, "FE4001", "잘못된 인증 코드입니다."),
     ALREADY_HAS_FAMILY(HttpStatus.BAD_REQUEST, "FE4002", "이미 가족에 등록된 사용자입니다."),
 
 

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -42,6 +42,9 @@ public enum StatusCode {
 
     // member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ME4001", "회원을 조회할 수 없습니다."),
+    FILE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5001", "파일 저장에 실패했습니다."),
+    DUPLICATE_FAMILY_CODE(HttpStatus.CONFLICT, "FE4002", "이미 사용 중인 가족 코드입니다."),
+
 
     // schedule
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "SC4001", "일정을 찾을 수 없습니다."),
@@ -53,6 +56,8 @@ public enum StatusCode {
 
     // family
     UNREGISTERED_FAMILY(HttpStatus.NOT_FOUND, "FE4001", "가족 정보가 등록되지 않았습니다."),
+    ALREADY_HAS_FAMILY(HttpStatus.BAD_REQUEST, "FE4002", "이미 가족에 등록된 사용자입니다."),
+
 
     // server
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER5001", "서버에서 에러가 발생했습니다."),

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -43,6 +43,8 @@ public enum StatusCode {
     // member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ME4001", "회원을 조회할 수 없습니다."),
     FILE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5001", "파일 저장에 실패했습니다."),
+    FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE4002", "파일이 비어있습니다."),
+
     DUPLICATE_FAMILY_CODE(HttpStatus.CONFLICT, "FE4002", "이미 사용 중인 가족 코드입니다."),
 
 


### PR DESCRIPTION
## 📌 작업 목적
회원가입 정보와 가족 코드 관련 API 구현

---

## 🔨 주요 작업 내용
- 회원가입 구현(닉네임, 성별, 생일, 임신 여부, 출산 예정일, 이전 임신 여부, 프로필 이미지 업로드 처리)
- 가족 코드 생성(자동 생성)/조회/수정
- 가족 그룹 생성

---

## 🧪 테스트 방법

- [ ] Postman으로 이미지 + 회원정보 전송 시 서버에 정상 저장되는지 확인
- [ ] /uploads/{파일명} 경로로 이미지 접근 가능한지 확인
- [ ] 에러 응답 시 메시지 출력 확인

---

## 📎 관련 이슈

- Closes #14 


---

## 💬 논의 또는 고민한 점
 
- 회원가입 때 프로필 이미지를 변경하지 않을 시 PROFILE_IMG_URL="/images/default-profile.png"으로 지정했습니다.
- 가족 코드로 페이지 접근에 대한 권한부분은 아직 구현하지 않았습니다. (가족코드 생성/수정/조회만 구현)

---

## 📷 스크린샷
회원가입
![image](https://github.com/user-attachments/assets/ff1071da-2f66-436f-8c99-d5a0696359fa)

프로필 이미지 확인
![image](https://github.com/user-attachments/assets/7e5ba956-a5b2-4ea4-a4ce-51a17461984f)

보호자가 정확한 가족 코드를 입력했을 경우
![image](https://github.com/user-attachments/assets/21f8624e-7b7d-4574-94d7-d12a411add0e)
보호자가 잘못된 가족 코드를 입력했을 경우
![image](https://github.com/user-attachments/assets/85f33335-0e51-42c7-86a9-3b1469c78367)


임산부가 가족 코드 생성한 경우
![image](https://github.com/user-attachments/assets/2116873b-b80e-4a9f-86b8-3957bb8790a7)
보호자가 가족 코드 생성할 경우
![image](https://github.com/user-attachments/assets/e3be0926-cbb1-4300-a0d5-3004d4da2d82)


---

## ✅ 체크리스트
- [ ] 회원가입 정보 저장
- [ ] 프로필 이미지 확인
- [ ] 임산부만 가족 코드 생성, 수정
- [ ] 보호자는 가족 코드 입력과 조회만 가능
