### PR TITLE
Feat/mypage (#18)

### DIFF
--- a/src/main/java/com/hanium/mom4u/Mom4uApplication.java
+++ b/src/main/java/com/hanium/mom4u/Mom4uApplication.java
@@ -3,7 +3,9 @@ package com.hanium.mom4u;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @EnableJpaAuditing
 public class Mom4uApplication {

--- a/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/repository/ScheduleRepository.java
@@ -14,5 +14,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     long countByMemberAndStartDate(Member member, LocalDate startDate);
 
+    void deleteByMember(Member member);
 
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.hanium.mom4u.domain.member.controller;
 
+import com.hanium.mom4u.domain.member.dto.response.ThemeResponse;
 import com.hanium.mom4u.domain.member.service.MemberService;
 import com.hanium.mom4u.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,7 +21,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @Operation(summary = "회원가입: 개인정보 입력", description = "회원정보를 입력합니다.")
+    @Operation(summary = "회원가입: 개인정보 입력/수정", description = "회원정보를 입력합니다.")
     @PatchMapping("/profile")
     public ResponseEntity<CommonResponse<Void>> updateProfile(
             @RequestParam("nickname") String nickname,
@@ -44,7 +45,6 @@ public class MemberController {
     public ResponseEntity<CommonResponse> getMyProfile() {
         return ResponseEntity.ok(CommonResponse.onSuccess(memberService.getMyProfile()));
     }
-
 
 }
 

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/SettingsController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/SettingsController.java
@@ -1,0 +1,33 @@
+package com.hanium.mom4u.domain.member.controller;
+
+import com.hanium.mom4u.domain.member.dto.request.ThemeRequest;
+import com.hanium.mom4u.domain.member.dto.response.ThemeResponse;
+import com.hanium.mom4u.domain.member.service.MemberService;
+import com.hanium.mom4u.domain.member.service.SettingsService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/settings")
+@RequiredArgsConstructor
+public class SettingsController {
+
+    private final SettingsService settingsService;
+
+    @Operation(summary = "테마 조회", description = "현재 웹의 테마를 조회합니다.")
+    @GetMapping("/theme")
+    public ResponseEntity<ThemeResponse> getTheme() {
+        return ResponseEntity.ok(new ThemeResponse(settingsService.getLightMode()));
+    }
+
+    @Operation(summary = "회원 테마 변경", description = "라이트 모드로 설정하려면 true, 다크 모드로 설정하려면 false를 입력하세요.")
+    @PostMapping("/theme")
+    public ResponseEntity<Void> updateTheme(@RequestBody ThemeRequest request) {
+        settingsService.updateLightMode(request.getTheme());
+        return ResponseEntity.ok().build();
+    }
+
+}
+

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/request/ThemeRequest.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/request/ThemeRequest.java
@@ -1,0 +1,14 @@
+package com.hanium.mom4u.domain.member.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ThemeRequest {
+    private Boolean theme;
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/response/MemberInfoResponse.java
@@ -9,11 +9,13 @@ import java.time.LocalDate;
 @AllArgsConstructor
 public class MemberInfoResponse {
     private String nickname;
+    private String email;
     private String imgUrl;
     private Boolean isPregnant;
     private LocalDate dueDate;
     private Boolean prePregnant;
     private String gender;
     private LocalDate birthDate;
+    private String socialType;
 }
 

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/response/ThemeResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/response/ThemeResponse.java
@@ -1,0 +1,10 @@
+package com.hanium.mom4u.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ThemeResponse {
+    private Boolean theme;
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
@@ -68,6 +68,8 @@ public class Member extends BaseEntity {
     @Column(name = "inactive_date")
     private LocalDate inactiveDate;
 
+    @Column(name = "is_light_mode")
+    private Boolean isLightMode;
 
     @ManyToOne
     @JoinColumn(name = "family_id")

--- a/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
@@ -75,10 +75,17 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "family_id")
     private Family family;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "member")
     private List<Baby> babyList;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "member")
     private List<Schedule> scheduleList;
 
+    public void inactive() {
+        this.isInactive = true;
+        this.inactiveDate = LocalDate.now();
+    }
+
 }
+
+

--- a/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
@@ -75,10 +75,10 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "family_id")
     private Family family;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Baby> babyList;
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Schedule> scheduleList;
 
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/repository/BabyRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/repository/BabyRepository.java
@@ -1,9 +1,12 @@
 package com.hanium.mom4u.domain.member.repository;
 
 import com.hanium.mom4u.domain.member.entity.Baby;
+import com.hanium.mom4u.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BabyRepository extends JpaRepository<Baby,Long> {
+    void deleteByMember(Member member);
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
@@ -5,11 +5,17 @@ import com.hanium.mom4u.domain.member.common.SocialType;
 import com.hanium.mom4u.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByEmailAndSocialType(String email, SocialType socialType);
 
     List<Member> findByFamily(Family family);
+
+    Optional<Member> findByEmailAndSocialTypeAndIsInactiveFalse(String email, SocialType socialType);
+
+    List<Member> findAllByIsInactiveTrueAndInactiveDateBefore(LocalDate date);
+
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/scheduler/MemberCleanupScheduler.java
@@ -1,0 +1,53 @@
+package com.hanium.mom4u.domain.member.scheduler;
+
+import com.hanium.mom4u.domain.calendar.repository.ScheduleRepository;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.BabyRepository;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberCleanupScheduler {
+
+    private final MemberRepository memberRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final BabyRepository babyRepository;
+
+    // 매일 12시 정각 실행
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void deleteInactiveMembersAfter7Days() {
+
+        LocalDate deadline = LocalDate.now().minusDays(7);
+        List<Member> expiredMembers = memberRepository.findAllByIsInactiveTrueAndInactiveDateBefore(deadline);
+
+        if (expiredMembers.isEmpty()) {
+            log.info("🟢 탈퇴 7일 지난 회원 없음.");
+            return;
+        }
+
+        for (Member member : expiredMembers) {
+            log.info("💀 회원 ID {} 의 연관 데이터를 먼저 삭제합니다.", member.getId());
+
+            // 연관 데이터 수동 삭제
+            babyRepository.deleteByMember(member);
+            scheduleRepository.deleteByMember(member);
+
+            // 회원 삭제
+            memberRepository.delete(member);
+            log.info("✅ 회원 ID {} 하드 삭제 완료.", member.getId());
+        }
+
+        log.info("🧹 총 {}명의 탈퇴 회원 하드 삭제 완료.", expiredMembers.size());
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -45,7 +45,15 @@ public class MemberService {
         member.setPrePregnant(prePregnant); // Member 엔티티에 prePregnant 필드 추가 필요
         member.setGender(gender);
         member.setBirthDate(birth); // Member 엔티티에 birth 필드 추가 필요
+
+        if (member.getIsLightMode() == null) {
+            member.setIsLightMode(true);
+        }
+
         memberRepository.save(member);
+
+
+
     }
 
     @Transactional(readOnly = true)
@@ -66,8 +74,5 @@ public class MemberService {
                 member.getSocialType().name()
         );
     }
-
-
-
 }
 

--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.hanium.mom4u.domain.member.service;
 
 import com.hanium.mom4u.domain.member.dto.response.MemberInfoResponse;
+import com.hanium.mom4u.domain.member.dto.response.ThemeResponse;
 import com.hanium.mom4u.domain.member.entity.Member;
 import com.hanium.mom4u.domain.member.repository.MemberRepository;
 import com.hanium.mom4u.global.exception.GeneralException;
@@ -55,14 +56,18 @@ public class MemberService {
 
         return new MemberInfoResponse(
                 member.getNickname(),
+                member.getEmail(),
                 member.getImgUrl(),
                 member.isPregnant(),
                 member.getDueDate(),
                 member.getPrePregnant(),
                 member.getGender(),
-                member.getBirthDate()
+                member.getBirthDate(),
+                member.getSocialType().name()
         );
     }
+
+
 
 }
 

--- a/src/main/java/com/hanium/mom4u/domain/member/service/SettingsService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/SettingsService.java
@@ -1,0 +1,40 @@
+package com.hanium.mom4u.domain.member.service;
+
+import com.hanium.mom4u.domain.member.dto.response.ThemeResponse;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
+import com.hanium.mom4u.global.security.jwt.AuthenticatedProvider;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SettingsService {
+
+    private final AuthenticatedProvider authenticatedProvider;
+    private final MemberRepository memberRepository;
+
+    public Boolean getLightMode() {
+        Member member = authenticatedProvider.getCurrentMember();
+        member = memberRepository.findById(member.getId())
+                .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
+        Boolean isLightMode = member.getIsLightMode();
+        return isLightMode != null ? isLightMode : true;
+    }
+
+
+    @Transactional
+    public void updateLightMode(Boolean isLightMode) {
+        Member member = authenticatedProvider.getCurrentMember();
+        member = memberRepository.findById(member.getId())
+                .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
+        member.setIsLightMode(isLightMode);
+        memberRepository.save(member);
+    }
+
+}
+
+

--- a/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         .requestMatchers("/test/**","/v3/api-docs/**", "/swagger-ui/**",
                                 "/swagger-resources/**", "/api-docs/**","/uploads/**",
                                 "/api/v1/auth/**").permitAll()
-                        .requestMatchers("/api/v1/schedules/**","api/v1/family-code/**").authenticated()
+                        .requestMatchers("/api/v1/schedules/**","api/v1/family-code/**","/api/v1/settings/**").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/hanium/mom4u/global/security/controller/AuthController.java
+++ b/src/main/java/com/hanium/mom4u/global/security/controller/AuthController.java
@@ -96,4 +96,15 @@ public class AuthController {
         authService.logout(request, response);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
+
+    @Operation(summary = "계정탈퇴 API", description = """
+            계정탈퇴 API 입니다.
+            """)
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<CommonResponse<Void>> withdraw(
+            HttpServletRequest request, HttpServletResponse response
+    ) {
+        authService.withdraw(request, response);
+        return ResponseEntity.ok(CommonResponse.onSuccess());
+    }
 }

--- a/src/main/java/com/hanium/mom4u/global/security/service/AuthService.java
+++ b/src/main/java/com/hanium/mom4u/global/security/service/AuthService.java
@@ -12,8 +12,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -57,4 +61,18 @@ public class AuthService {
         refreshTokenUtil.deleteRefreshToken(memberId);
         refreshTokenUtil.removeRefreshTokenCookie(response);
     }
+
+
+    @Transactional
+    public void withdraw(HttpServletRequest request, HttpServletResponse response) {
+        Long memberId = refreshTokenUtil.getMemberIdFromCookie(request);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(StatusCode.MEMBER_NOT_FOUND));
+
+        member.inactive();  // Soft delete 처리
+
+        refreshTokenUtil.deleteRefreshToken(memberId);
+        refreshTokenUtil.removeRefreshTokenCookie(response);
+    }
+
 }

--- a/src/main/java/com/hanium/mom4u/global/security/service/GoogleLoginService.java
+++ b/src/main/java/com/hanium/mom4u/global/security/service/GoogleLoginService.java
@@ -34,8 +34,8 @@ public class GoogleLoginService {
         GoogleProfileResponseDto profile = googleUtil.findProfile(
                 googleUtil.getToken(code).getAccessToken())
                 ;
-        Member member = memberRepository.findByEmailAndSocialType(
-                profile.getEmail(), SocialType.GOOGLE)
+        Member member = memberRepository.findByEmailAndSocialTypeAndIsInactiveFalse(
+                        profile.getEmail(), SocialType.GOOGLE)
                 .orElseGet(() -> {
                     Member newMember = Member.builder()
                             .name(profile.getName())
@@ -46,6 +46,7 @@ public class GoogleLoginService {
                             .build();
                     return memberRepository.save(newMember);
                 });
+
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());

--- a/src/main/java/com/hanium/mom4u/global/security/service/KakaoLoginService.java
+++ b/src/main/java/com/hanium/mom4u/global/security/service/KakaoLoginService.java
@@ -52,7 +52,7 @@ public class KakaoLoginService {
         String email = userInfo.getKakaoAccount().getEmail();
         String nickname = userInfo.getKakaoAccount().getProfile().getNickname();
 
-        Member member = memberRepository.findByEmailAndSocialType(email, SocialType.KAKAO)
+        Member member = memberRepository.findByEmailAndSocialTypeAndIsInactiveFalse(email, SocialType.KAKAO)
                 .orElseGet(() -> {
                     Member newMember = new Member();
                     newMember.setEmail(email);
@@ -61,6 +61,7 @@ public class KakaoLoginService {
                     newMember.setSocialType(SocialType.KAKAO);
                     return memberRepository.save(newMember);
                 });
+
 
         // 토큰 생성
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());

--- a/src/main/java/com/hanium/mom4u/global/security/service/NaverLoginService.java
+++ b/src/main/java/com/hanium/mom4u/global/security/service/NaverLoginService.java
@@ -30,7 +30,8 @@ public class NaverLoginService {
     @Transactional
     public LoginResponseDto loginWithNaver(HttpServletResponse response, String code, String state) {
         NaverProfileResponseDto profile = naverUtil.findProfile(naverUtil.getToken(code, state).getAccessToken());
-        Member member = memberRepository.findByEmailAndSocialType(profile.getResponse().email, SocialType.NAVER)
+        Member member = memberRepository.findByEmailAndSocialTypeAndIsInactiveFalse(
+                        profile.getResponse().getEmail(), SocialType.NAVER)
                 .orElseGet(() -> {
                     Member newMember = Member.builder()
                             .name(profile.getResponse().getName())
@@ -46,6 +47,7 @@ public class NaverLoginService {
                             .build();
                     return memberRepository.save(newMember);
                 });
+
 
         String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole());
         String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());


### PR DESCRIPTION
## 📌 작업 목적
마이페이지를 구현합니다.

---

## 🔨 주요 작업 내용

- [x] 테마 설정

- [x] 개인정보 확인

- [x] 계정탈퇴 ( 휴면계정 7일 뒤 탈퇴 )

---

## 🧪 테스트 방법
기존 기준: 휴면 상태가 된 후 7일이 지나면 자동 탈퇴

테스트 변경 사항:

자동 탈퇴 기준을 7일 → 1일로 변경

테스트를 위해 휴면 계정 전환일을 '2일 전'로 설정

따라서, 휴면 전환일로부터 1일이 경과된 상태이므로, 현재 시점에서 해당 계정은 자동 탈퇴 대상이 되어야 함
![image](https://github.com/user-attachments/assets/395353b8-aa87-4990-b09b-2f11f4faacbe)


![image](https://github.com/user-attachments/assets/53536ea7-128d-47e4-8ab2-b81b8d5f74f0)

---

## 📎 관련 이슈
#18 

---


## 📷 스크린샷
테스트 전
![image](https://github.com/user-attachments/assets/5feaea43-9282-487a-a00e-999050d3f033)



**테마 설정**
테마를 따로 설정하지 않았을 경우 기본 (light)
![image](https://github.com/user-attachments/assets/b3a02516-3f8b-44be-8429-3596961a7d28)
테마를 다크로 설정
![image](https://github.com/user-attachments/assets/0e44ad6b-936c-458d-af45-d74c61db7f87)

**개인정보 조회**
기존에 email, socialType 추가
![image](https://github.com/user-attachments/assets/61a043c8-2ede-406a-a9bb-004257a8890c)

**계정 탈퇴**
![image](https://github.com/user-attachments/assets/7f404130-4faa-45ca-a2e4-61e2861404c7)

1분이 지남(테스트를 위해 오전 12시 주기를 1분으로 바꿈)
![image](https://github.com/user-attachments/assets/c92dc059-9ab5-475b-8a64-88adcc10be2d)
![image](https://github.com/user-attachments/assets/546ba977-567a-4f46-b0f5-f8b6d8c98a8c)

![image](https://github.com/user-attachments/assets/7f813428-9dea-41da-9732-c6e4752e9aaa)
![image](https://github.com/user-attachments/assets/8fe58990-b50c-471b-af11-4f930ddee067)

원래는 스케줄링이 오전 12시마다 되도록 설정


 
---

## ✅ 체크리스트
- [x] 마이페이지에 정보 북마크는 구현되지 않았습니다.

