### PR TITLE
Fix/nginx reload (#30)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@v1

--- a/nginx/nginx.blue.conf
+++ b/nginx/nginx.blue.conf
@@ -1,7 +1,5 @@
-events {}
-
 upstream app {
-    server dearbelly-api-blue:8080;
+    server 127.0.0.1:8080; #blue
 }
 
 server {

--- a/nginx/nginx.green.conf
+++ b/nginx/nginx.green.conf
@@ -1,7 +1,5 @@
-events {}
-
 upstream app {
-    server dearbelly-api-green:8080;
+    server 127.0.0.1:8081; #green
 }
 
 server {


### PR DESCRIPTION
## 📌 작업 목적
Docker를 통한 블루/그린 무중단 배포를 위해선 컨테이너가 변경될 때마다 nginx로 리로드 필요

---

## 🔨 주요 작업 내용
- 기존의 `[컨테이너 이름]:8080' 작성 -> localhost:8080 으로 변경
- 동일한 네트워크 상의 컨테이너일 때만 컨테이너 이름을 통하여 포트매핑이 가능하기에  host에 설치하니 오류 발생
- localhost:8080(blue), localhost:8081(green) 으로 변경하였습니다
- 현재 바뀐 버전
<img width="901" height="603" alt="image" src="https://github.com/user-attachments/assets/430fe9bb-6210-4896-b714-c2840d490eaf" />


---
