### PR TITLE
Fix/member profile 38 (#38)

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
@@ -1,7 +1,6 @@
 package com.hanium.mom4u.domain.member.controller;
 
 import com.hanium.mom4u.domain.member.dto.request.ProfileEditRequest;
-import com.hanium.mom4u.domain.member.dto.response.ThemeResponse;
 import com.hanium.mom4u.domain.member.service.MemberService;
 import com.hanium.mom4u.global.response.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,7 +44,7 @@ public class MemberController {
         return ResponseEntity.ok(CommonResponse.onSuccess(presignedUrl));
     }
 
-    @Operation(summary = "프로필 이미지 저장", description = "이미지 업로드 후 URL을 사용자 정보에 반영합니다.")
+    @Operation(summary = "프로필 이미지 저장", description = "이미지 업로드 후(프론트에서 put해야함) URL을 사용자 정보에 반영합니다.")
     @PatchMapping("/profile/image")
     public ResponseEntity<CommonResponse<Void>> updateProfileImage(@RequestParam("imgUrl") String imgUrl) {
         memberService.updateProfileImage(imgUrl);

--- a/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
@@ -5,6 +5,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.auth.credentials.*;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
@@ -59,6 +61,26 @@ public class FileStorageService {
         presigner.close();
 
         return presignedPutUrl.toString();
+    }
+
+
+    public void deleteFile(String objectKey) {
+        S3Client s3Client = S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        (accessKey != null && secretKey != null) ?
+                                StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)) :
+                                DefaultCredentialsProvider.create()
+                )
+                .build();
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(objectKey)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+        s3Client.close();
     }
 
 

--- a/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/FileStorageService.java
@@ -31,7 +31,6 @@ public class FileStorageService {
     @Value("${spring.cloud.aws.s3.secret-key}") // optional - 로컬에서만 필요
     private String secretKey;
 
-
     public String generatePresignedPutUrl(String objectKey) {
         S3Presigner presigner;
 

--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -51,16 +51,23 @@ public class MemberService {
         return fileStorageService.generatePresignedPutUrl(objectKey);
     }
 
+    //기본 이미지가 아닌 경우 S3에서 삭제
+    private void deleteIfCustomImage(String imageUrl) {
+        if (imageUrl != null && !imageUrl.isBlank()
+                && !imageUrl.equals(DEFAULT_PROFILE_IMG_URL)) {
+            String objectKey = extractKeyFromUrl(imageUrl);
+            fileStorageService.deleteFile(objectKey);
+        }
+    }
+
+
     public void updateProfileImage(String newImgUrl) {
         Member member = authenticatedProvider.getCurrentMember();
         String oldImgUrl = member.getImgUrl();
 
 
-        if (oldImgUrl != null && !oldImgUrl.isBlank()
-                && !oldImgUrl.equals(DEFAULT_PROFILE_IMG_URL)) {
-            String objectKey = extractKeyFromUrl(oldImgUrl);
-            fileStorageService.deleteFile(objectKey);
-        }
+        deleteIfCustomImage(oldImgUrl);
+
 
         member.setImgUrl(newImgUrl);
         memberRepository.save(member);
@@ -86,14 +93,7 @@ public class MemberService {
         }
 
         if (request.getImgUrl() != null) {
-            String oldImgUrl = member.getImgUrl();
-
-            // 삭제 로직 추가
-            if (oldImgUrl != null && !oldImgUrl.isBlank()
-                    && !oldImgUrl.equals(DEFAULT_PROFILE_IMG_URL)) {
-                String objectKey = extractKeyFromUrl(oldImgUrl);
-                fileStorageService.deleteFile(objectKey);
-            }
+            deleteIfCustomImage(member.getImgUrl());
 
             // 새로운 값 적용
             if (request.getImgUrl().isBlank()) {

--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -87,18 +86,26 @@ public class MemberService {
         }
 
         if (request.getImgUrl() != null) {
+            String oldImgUrl = member.getImgUrl();
+
+            // 삭제 로직 추가
+            if (oldImgUrl != null && !oldImgUrl.isBlank()
+                    && !oldImgUrl.equals(DEFAULT_PROFILE_IMG_URL)) {
+                String objectKey = extractKeyFromUrl(oldImgUrl);
+                fileStorageService.deleteFile(objectKey);
+            }
+
+            // 새로운 값 적용
             if (request.getImgUrl().isBlank()) {
-                // 빈 문자열이면 기본 이미지로 설정
                 member.setImgUrl(DEFAULT_PROFILE_IMG_URL);
             } else {
-                // 새 이미지로 설정
                 member.setImgUrl(request.getImgUrl());
             }
         }
 
+
         memberRepository.save(member);
     }
-
     @Transactional(readOnly = true)
     public MemberInfoResponse getMyProfile() {
         Member member = authenticatedProvider.getCurrentMember();
@@ -110,10 +117,11 @@ public class MemberService {
             imageUrl = DEFAULT_PROFILE_IMG_URL;
         }
 
+
         return new MemberInfoResponse(
                 member.getNickname(),
                 member.getEmail(),
-                imageUrl, // 수정된 이미지 URL 사용
+                imageUrl,
                 member.isPregnant(),
                 member.getDueDate(),
                 member.getPrePregnant(),

--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -25,6 +25,7 @@ public class MemberService {
     @Value("${spring.cloud.aws.s3.default-image}")
     private String DEFAULT_PROFILE_IMG_URL;
 
+
     public void updateProfile(String nickname, Boolean isPregnant,
                               LocalDate dueDate, Boolean prePregnant, String gender, LocalDate birth) {
         Member member = authenticatedProvider.getCurrentMember();


### PR DESCRIPTION
## 📌 작업 목적

프로필 이미지 관리 개선: 사용자별 S3 디렉토리 구성 및 기존 이미지 삭제 기능 구현

---

## 🔨 주요 작업 내용

- S3 Presigned URL 업로드 시 사용자 ID 기반 Key Prefix (images/{memberId}/{filename})로 객체 저장
- 프로필 이미지 변경 시 기존 이미지가 기본 이미지가 아니라면 S3에서 자동 삭제
- 빈 이미지("") 입력 시 기본 이미지로 초기화

---

## 🧪 테스트 방법

- [x] 새로운 이미지 업로드 후 S3에 images/{memberId}/ 경로로 저장되는지 확인
- [x] 이미지 변경 시 S3에서 이전 이미지가 삭제되는지 확인
- [x] 이미지 URL이 빈 문자열일 경우 기본 이미지로 설정되는지 확인


---

## 📎 관련 이슈
  
- #38  

---

## 💬 논의 또는 고민한 점

- 기본 이미지 URL과 사용자가 업로드한 이미지 구분 방식 (.amazonaws.com/ 기준 split)



---

## 📷 스크린샷

#### 회원 ID별로 프로필 사진이 저장
<img width="280" height="531" alt="image" src="https://github.com/user-attachments/assets/09420103-2bdc-42c9-a9f9-4dbb3c80932b" />

<img width="185" height="53" alt="image" src="https://github.com/user-attachments/assets/99b8266f-2200-45be-9c09-5267622f2861" />
<img width="232" height="412" alt="image" src="https://github.com/user-attachments/assets/4b48f7d5-e292-499e-b2dd-71374464141d" />

#### 프로필 사진을 새 이미지로 변경했을 때 (기존 이미지가 삭제됨)
<img width="172" height="47" alt="image" src="https://github.com/user-attachments/assets/e57b0682-e0bb-48e4-8be0-93868707c0b1" />
<img width="256" height="453" alt="image" src="https://github.com/user-attachments/assets/4506a0a1-0587-49a4-a258-78025db4fee0" />


#### 프로필 사진을 기본 이미지로 했을 때 (기본 이미지는 S3의 공용 위치에 있으며, 사용자별 경로에 저장되지 않음)
<img width="260" height="108" alt="image" src="https://github.com/user-attachments/assets/5728d222-e1e4-427b-9a4e-b4198d6542f7" />
<img width="237" height="132" alt="image" src="https://github.com/user-attachments/assets/aaff7b54-51fc-4672-93b3-eddd0aec7c20" />



---


