### PR TITLE
Feat/home letter (#47)

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
@@ -4,6 +4,8 @@ import com.hanium.mom4u.domain.family.entity.Family;
 import com.hanium.mom4u.domain.member.common.SocialType;
 import com.hanium.mom4u.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -17,5 +19,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findAllByIsInactiveTrueAndInactiveDateBefore(LocalDate date);
 
-
+    @Query("SELECT COUNT(m) FROM Member m WHERE m.family.id = :familyId")
+    long countByFamilyId(@Param("familyId") Long familyId);
 }

--- a/src/main/java/com/hanium/mom4u/domain/question/controller/HomeController.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/controller/HomeController.java
@@ -27,4 +27,5 @@ public class HomeController {
     }
 
 
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/question/controller/HomeController.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/controller/HomeController.java
@@ -1,0 +1,30 @@
+package com.hanium.mom4u.domain.question.controller;
+
+import com.hanium.mom4u.domain.question.dto.response.HomeResponse;
+import com.hanium.mom4u.domain.question.service.HomeService;
+import com.hanium.mom4u.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/home")
+@RequiredArgsConstructor
+@Tag(name = "홈 페이지")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @Operation(
+            summary = "홈 상단 배너 조회",
+            description = "아기 이름, 오늘 기준 0주차부터 계산된 주차, 그리고 '남이 쓴 미열람 편지' 여부를 반환합니다."
+    )
+    @GetMapping("/top")
+    public ResponseEntity<CommonResponse<HomeResponse>> top() {
+        return ResponseEntity.ok(CommonResponse.onSuccess(homeService.getTopBanner()));
+    }
+
+
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/controller/LetterController.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/controller/LetterController.java
@@ -1,0 +1,70 @@
+package com.hanium.mom4u.domain.question.controller;
+
+import com.hanium.mom4u.domain.question.dto.request.LetterRequest;
+import com.hanium.mom4u.domain.question.dto.response.LetterResponse;
+import com.hanium.mom4u.domain.question.service.LetterService;
+import com.hanium.mom4u.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/letters")
+@RequiredArgsConstructor
+@Tag(name = "편지함")
+public class LetterController {
+
+    private final LetterService letterService;
+
+    @Operation(summary = "편지 쓰기 API", description = "편지 작성 API입니다.")
+    @PostMapping
+    public ResponseEntity<CommonResponse<Long>> create(@RequestBody @Valid LetterRequest request) {
+        Long letterId = letterService.create(request);
+        return ResponseEntity.ok(CommonResponse.onSuccess(letterId));
+    }
+
+    @Operation(
+            summary = "편지 월별 조회 API",
+            description = "같은 가족의 편지를 월 단위로 조회합니다. year/month 미지정 시 이번 달을 기준으로 합니다."
+    )
+    @GetMapping
+    public ResponseEntity<CommonResponse<List<LetterResponse>>> getByMonth(
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month) {
+        List<LetterResponse> responses = letterService.getByMonth(year, month);
+        return ResponseEntity.ok(CommonResponse.onSuccess(responses));
+    }
+
+    @Operation(
+            summary = "편지 상세 조회 API",
+            description = "편지 1건을 조회합니다. 조회 시 현재 사용자 기준으로 '남이 쓴 글'만 읽음 처리됩니다."
+    )
+    @GetMapping("/{id}")
+    public ResponseEntity<CommonResponse<LetterResponse>> getDetail(@PathVariable Long id) {
+        return ResponseEntity.ok(CommonResponse.onSuccess(letterService.getDetail(id)));
+    }
+
+
+    @Operation(
+            summary = "편지 수정 API", description = "작성자 본인만 자신의 편지를 수정할 수 있습니다.")
+    @PutMapping("/{id}")
+    public ResponseEntity<CommonResponse<Void>> update(
+            @PathVariable Long id, @RequestBody @Valid LetterRequest request) {
+        letterService.update(id, request);
+        return ResponseEntity.ok(CommonResponse.onSuccess());
+    }
+
+    @Operation(summary = "편지 삭제 API", description = "작성자 본인만 삭제할 수 있습니다.")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<CommonResponse<Void>> delete(@PathVariable Long id) {
+        letterService.delete(id);
+        return ResponseEntity.ok(CommonResponse.onSuccess());
+    }
+}
+
+

--- a/src/main/java/com/hanium/mom4u/domain/question/dto/request/LetterRequest.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/dto/request/LetterRequest.java
@@ -1,0 +1,17 @@
+package com.hanium.mom4u.domain.question.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LetterRequest {
+
+    @Size(max = 300, message = "내용은 300자 이하여야 합니다.")
+    private String content;
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/dto/response/HomeResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/dto/response/HomeResponse.java
@@ -1,0 +1,15 @@
+package com.hanium.mom4u.domain.question.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class HomeResponse {
+    private String babyName;          // 아기 이름
+    private int week;                 // 오늘 기준 0부터
+    private boolean hasUnreadLetters; // true면 편지 아이콘 표시
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/dto/response/HomeResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/dto/response/HomeResponse.java
@@ -12,4 +12,5 @@ public class HomeResponse {
     private String babyName;          // 아기 이름
     private int week;                 // 오늘 기준 0부터
     private boolean hasUnreadLetters; // true면 편지 아이콘 표시
+
 }

--- a/src/main/java/com/hanium/mom4u/domain/question/dto/response/LetterResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/dto/response/LetterResponse.java
@@ -1,0 +1,20 @@
+package com.hanium.mom4u.domain.question.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+@Builder
+@Getter
+@AllArgsConstructor
+public class LetterResponse {
+
+    private Long id;
+    private String content;
+    private String nickname;
+    private String imgUrl;
+    private LocalDateTime createdAt;
+    private boolean editable; // 내가 쓴 글인지
+
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/entity/Letter.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/entity/Letter.java
@@ -1,0 +1,34 @@
+package com.hanium.mom4u.domain.question.entity;
+
+import com.hanium.mom4u.domain.common.BaseEntity;
+import com.hanium.mom4u.domain.family.entity.Family;
+import com.hanium.mom4u.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "letter")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Letter extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "letter_id")
+    private Long id;
+
+    @Column(name = "content", nullable = false, length = 300)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "writer_id")
+    private Member writer;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "family_id", nullable = true)
+    private Family family;
+
+    public void updateContent(String content){ this.content = content; }
+}
+

--- a/src/main/java/com/hanium/mom4u/domain/question/entity/LetterRead.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/entity/LetterRead.java
@@ -1,0 +1,41 @@
+package com.hanium.mom4u.domain.question.entity;
+
+import com.hanium.mom4u.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.FetchType.LAZY;
+@Builder
+@Getter
+@Entity
+@Table(name="letter_read",
+        uniqueConstraints=@UniqueConstraint(columnNames={"letter_id","reader_id"}))
+@NoArgsConstructor
+@AllArgsConstructor
+public class LetterRead {
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch= LAZY, optional=false) @JoinColumn(name="letter_id")
+    private Letter letter;
+
+    @ManyToOne(fetch=LAZY, optional=false) @JoinColumn(name="reader_id")
+    private Member reader;
+
+    @Column(name = "read_at", nullable = false)
+    private LocalDateTime readAt;
+
+    public static LetterRead of(Letter letter, Member reader) {
+        return LetterRead.builder()
+                .letter(letter)
+                .reader(reader)
+                .readAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/repository/LetterReadRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/repository/LetterReadRepository.java
@@ -1,0 +1,23 @@
+package com.hanium.mom4u.domain.question.repository;
+
+import com.hanium.mom4u.domain.question.entity.LetterRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface LetterReadRepository extends JpaRepository<LetterRead, Long> {
+
+
+    /** 남이 쓴 것 중 내가 안 읽은 편지 개수 (가족 단위) */
+    @Query("""
+        SELECT COUNT(l) FROM Letter l
+        WHERE l.family.id = :familyId
+          AND l.writer.id <> :memberId
+          AND NOT EXISTS (
+              SELECT 1 FROM LetterRead r
+              WHERE r.letter = l AND r.reader.id = :memberId
+          )
+    """)
+    long countUnreadForMember(@Param("familyId") Long familyId,
+                              @Param("memberId") Long memberId);
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/repository/LetterRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/repository/LetterRepository.java
@@ -1,0 +1,33 @@
+package com.hanium.mom4u.domain.question.repository;
+
+import com.hanium.mom4u.domain.family.entity.Family;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.question.entity.Letter;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface LetterRepository extends JpaRepository<Letter, Long> {
+
+    @Query("""
+        select i
+        from Letter i
+        where i.family = :family
+          and i.createdAt between :start and :end
+        order by i.createdAt desc
+    """)
+    List<Letter> findByFamilyAndCreatedAtBetween(
+            Family family, LocalDateTime start, LocalDateTime end);
+
+
+    @Query("""
+      select l from Letter l
+      where l.writer = :writer
+        and l.createdAt between :start and :end
+      order by l.createdAt desc
+    """)
+    List<Letter> findByWriterAndCreatedAtBetween(
+            Member writer, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/service/HomeService.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/service/HomeService.java
@@ -1,0 +1,67 @@
+package com.hanium.mom4u.domain.question.service;
+
+import com.hanium.mom4u.domain.member.entity.Baby;
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.member.repository.BabyRepository;
+import com.hanium.mom4u.domain.member.repository.MemberRepository;
+import com.hanium.mom4u.domain.question.dto.response.HomeResponse;
+import com.hanium.mom4u.domain.question.repository.LetterReadRepository;
+import com.hanium.mom4u.global.security.jwt.AuthenticatedProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private final BabyRepository babyRepository;
+    private final MemberRepository memberRepository;
+    private final LetterReadRepository letterReadRepository;
+    private final AuthenticatedProvider authenticatedProvider;
+
+    /** 아기 이름, 주차(0부터), 편지 읽음 여부 */
+    public HomeResponse getTopBanner() {
+        Member me = authenticatedProvider.getCurrentMember();
+
+        // 1) 임산부면 본인 진행 중 아기, 2) 아니면 가족 진행 중 아기
+        java.util.Optional<Baby> babyOpt = me.isPregnant()
+                ? babyRepository.findCurrentByMemberId(me.getId())
+                : findFamilyOngoingBaby(me);
+
+        boolean hasUnread = hasUnreadLetterIcon(me);
+
+        //  아기 없으면 기본값으로 응답 (에러 X)
+        if (babyOpt.isEmpty()) {
+            return HomeResponse.builder()
+                    .babyName(null)      // 프론트에서 placeholder 처리
+                    .week(0)             // 0주차
+                    .hasUnreadLetters(hasUnread)
+                    .build();
+        }
+
+        Baby baby = babyOpt.get();
+        String babyName = (baby.getName() == null || baby.getName().isBlank()) ? null : baby.getName();
+
+        return HomeResponse.builder()
+                .babyName(babyName)
+                .week(baby.getCurrentWeek())     // LMP 기준 0주차부터
+                .hasUnreadLetters(hasUnread)
+                .build();
+    }
+
+    /** 같은 가족의 진행 중 아기 1건 Optional (가족 없으면 empty) */
+    private java.util.Optional<Baby> findFamilyOngoingBaby(Member me) {
+        if (me.getFamily() == null) return java.util.Optional.empty();
+        return babyRepository.findCurrentByFamilyId(me.getFamily().getId());
+    }
+
+
+    private boolean hasUnreadLetterIcon(Member me) {
+        if (me.getFamily() == null) return false;
+        Long familyId = me.getFamily().getId();
+        if (memberRepository.countByFamilyId(familyId) <= 1) return false;
+        return letterReadRepository.countUnreadForMember(familyId, me.getId()) > 0;
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/service/LetterReadService.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/service/LetterReadService.java
@@ -1,0 +1,26 @@
+package com.hanium.mom4u.domain.question.service;
+
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.question.entity.Letter;
+import com.hanium.mom4u.domain.question.entity.LetterRead;
+import com.hanium.mom4u.domain.question.repository.LetterReadRepository;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+
+@Service
+@RequiredArgsConstructor
+public class LetterReadService {
+    private final LetterReadRepository letterReadRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markAsRead(Letter letter, Member me) {
+        try {
+            letterReadRepository.save(LetterRead.of(letter, me));
+        } catch (org.springframework.dao.DataIntegrityViolationException ignore) {
+            // 이미 읽음 → 무시 (이 트랜잭션만 롤백)
+        }
+    }
+}
+

--- a/src/main/java/com/hanium/mom4u/domain/question/service/LetterService.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/service/LetterService.java
@@ -1,0 +1,128 @@
+package com.hanium.mom4u.domain.question.service;
+
+import com.hanium.mom4u.domain.member.entity.Member;
+import com.hanium.mom4u.domain.question.dto.request.LetterRequest;
+import com.hanium.mom4u.domain.question.dto.response.LetterResponse;
+import com.hanium.mom4u.domain.question.entity.Letter;
+import com.hanium.mom4u.domain.question.repository.LetterRepository;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
+import com.hanium.mom4u.global.security.jwt.AuthenticatedProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LetterService {
+
+    private final LetterRepository letterRepository;
+    private final AuthenticatedProvider authenticatedProvider;
+    private final LetterReadService letterreadService;
+
+    public Long create(LetterRequest req) {
+        Member me = authenticatedProvider.getCurrentMember(); // 가족 정보 확인용
+        String content = req.getContent().trim();
+        if (content.isEmpty()) throw GeneralException.of(StatusCode.LETTER_CONTENT_REQUIRED);
+        if (content.length() > 300) throw GeneralException.of(StatusCode.LETTER_CONTENT_TOO_LONG);
+
+        // 가족이 없어도 저장 가능 (family=null)
+        Letter letter = Letter.builder()
+                .content(content)
+                .writer(me)
+                .family(me.getFamily()) // null 가능
+                .build();
+
+        return letterRepository.save(letter).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<LetterResponse> getByMonth(Integer year, Integer month) {
+        Member me = authenticatedProvider.getCurrentMember();
+        YearMonth ym = (year == null || month == null) ? YearMonth.now() : YearMonth.of(year, month);
+        LocalDateTime start = ym.atDay(1).atStartOfDay();
+        LocalDateTime end = ym.atEndOfMonth().atTime(23,59,59);
+
+        List<Letter> letters;
+        if (me.getFamily() != null) {
+            // 가족이 있으면 가족 편지 전체
+            letters = letterRepository.findByFamilyAndCreatedAtBetween(me.getFamily(), start, end);
+        } else {
+            // 가족이 없으면 내 편지만
+            letters = letterRepository.findByWriterAndCreatedAtBetween(me, start, end);
+        }
+
+        return letters.stream()
+                .map(l -> LetterResponse.builder()
+                        .id(l.getId())
+                        .content(l.getContent())
+                        .nickname(l.getWriter().getNickname())
+                        .imgUrl(l.getWriter().getImgUrl())
+                        .createdAt(l.getCreatedAt())
+                        .editable(l.getWriter().getId().equals(me.getId()))
+                        .build())
+                .toList();
+    }
+
+    public void update(Long letterId, LetterRequest req) {
+        Long myId = authenticatedProvider.getCurrentMemberId();
+        String content = req.getContent().trim();
+        if (content.isEmpty()) throw GeneralException.of(StatusCode.LETTER_CONTENT_REQUIRED);
+        if (content.length() > 300) throw GeneralException.of(StatusCode.LETTER_CONTENT_TOO_LONG);
+
+        Letter letter = letterRepository.findById(letterId)
+                .orElseThrow(() -> GeneralException.of(StatusCode.LETTER_NOT_FOUND));
+        if (!letter.getWriter().getId().equals(myId))
+            throw GeneralException.of(StatusCode.LETTER_FORBIDDEN);
+
+        letter.updateContent(content);
+    }
+
+    public void delete(Long letterId) {
+        Long myId = authenticatedProvider.getCurrentMemberId();
+        Letter letter = letterRepository.findById(letterId)
+                .orElseThrow(() -> GeneralException.of(StatusCode.LETTER_NOT_FOUND));
+        if (!letter.getWriter().getId().equals(myId))
+            throw GeneralException.of(StatusCode.LETTER_FORBIDDEN);
+
+        letterRepository.delete(letter);
+    }
+
+    @Transactional(readOnly = true)
+    public LetterResponse getDetail(Long letterId) {
+        Member me = authenticatedProvider.getCurrentMember();
+        Letter letter = letterRepository.findById(letterId)
+                .orElseThrow(() -> GeneralException.of(StatusCode.LETTER_NOT_FOUND));
+
+        // 권한 체크
+        if (letter.getFamily() != null) {
+            if (me.getFamily() == null || !letter.getFamily().getId().equals(me.getFamily().getId())) {
+                throw GeneralException.of(StatusCode.LETTER_FORBIDDEN);
+            }
+        } else if (!letter.getWriter().getId().equals(me.getId())) {
+            throw GeneralException.of(StatusCode.LETTER_FORBIDDEN);
+        }
+
+        //  읽음 처리는 별도 트랜잭션으로
+        if (letter.getFamily() != null && !letter.getWriter().getId().equals(me.getId())) {
+            letterreadService.markAsRead(letter, me);
+        }
+
+        return LetterResponse.builder()
+                .id(letter.getId())
+                .content(letter.getContent())
+                .nickname(letter.getWriter().getNickname())
+                .imgUrl(letter.getWriter().getImgUrl())
+                .createdAt(letter.getCreatedAt())
+                .editable(letter.getWriter().getId().equals(me.getId()))
+                .build();
+    }
+
+
+}
+

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -66,6 +66,13 @@ public enum StatusCode {
     // family
     UNREGISTERED_FAMILY(HttpStatus.NOT_FOUND, "FE4001", "잘못된 인증 코드입니다."),
 
+    //letter
+    LETTER_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "LE4001", "편지 내용은 필수입니다."),
+    LETTER_FORBIDDEN(HttpStatus.FORBIDDEN,    "LE4031", "편지에 접근 권한이 없습니다."),
+    LETTER_NOT_FOUND(HttpStatus.NOT_FOUND,    "LE4041", "편지를 찾을 수 없습니다."),
+    LETTER_CONTENT_TOO_LONG (HttpStatus.BAD_REQUEST, "LE4002", "편지 내용은 300자 이하여야 합니다."),
+
+
     // server
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER5001", "서버에서 에러가 발생했습니다."),
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "JSON400", "JSON 형식 오류"),


### PR DESCRIPTION
## 📌 작업 목적

홈 페이지에서 아기 이름과 주차를 반환하고, 편지 이모티콘 표시 여부를 구현했습니다. 
또한 편지 기능(조회, 작성, 읽음 처리)을 추가했습니다.

---

## 🗂 작업 유형

- [ ] 기능 추가 (Feature)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

- 홈 화면에서 아기 이름과 임신 주차(0주차부터) 계산 로직 구현

- 읽지 않은 편지가 있을 경우 편지 이모티콘 여부 구현

- 편지 작성, 조회, 상세조회, 삭제, 수정, 읽음 처리 API 구현

- 날짜 기반 주차 계산 로직 추가

- Letter 엔티티: 편지 내용, 작성자, 가족 관계 저장

- LetterRead 엔티티: 특정 회원이 특정 편지를 읽었는지 여부 저장 (읽음 처리 전용 테이블)


---

## 🧪 테스트 결과

### 가족끼리 편지 조회(년도와 월을 지정하지 않으면 최신순으로 정렬되어 반환)
#### 해당 편지가 본인이 작성한 것인지 여부를 나타냄
<img width="286" height="352" alt="image" src="https://github.com/user-attachments/assets/d5b47e77-de35-4382-abc6-263760570193" />

### 편지 내용이 300자를 초과하면 작성이 불가
<img width="420" height="142" alt="image" src="https://github.com/user-attachments/assets/14cd12cb-307c-4639-a820-177ba22515b8" />

### 타인이 쓴 편지 수정,삭제할 경우
<img width="362" height="143" alt="image" src="https://github.com/user-attachments/assets/6c303d45-7b71-4319-8c0e-0e03749b5c52" />

### 홈: 타인이 작성한 편지 중 아직 상세 조회하지 않은 편지가 있을 경우, 편지 아이콘이 표시(hasUnreadLetters=true)
<img width="307" height="247" alt="image" src="https://github.com/user-attachments/assets/67d16452-32a8-41ba-85c5-ddf566621e7e" />

### 홈: 타인이 쓴 편지를 모두 상세조회한 경우(hasUnreadLetters=false)
<img width="330" height="245" alt="image" src="https://github.com/user-attachments/assets/02a56f1e-7e0f-4397-bdc5-53b0b7cb0507" />

---

## 📎 관련 이슈

- Closes #47 

---

## 💬 논의 및 고민한 점

Letter와 LetterRead를 분리하여 편지 자체 데이터와 읽음 상태를 독립적으로 관리
상세 조회를 했을 경우에만 읽음 처리(전체 조회에서는 읽음 처리X)

---

## ✅ 체크리스트
- [ ] 모든 단위/통합 테스트를 통과했습니다
- [ ] 홈 페이지에 카테고리별 정보 반환은 구현되지 않았습니다.
