### PR TITLE
[FIX] Redis Stream 태스크 발행 오류 수정

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/scan/registry/PendingSinkRegistry.java
+++ b/src/main/java/com/hanium/mom4u/domain/scan/registry/PendingSinkRegistry.java
@@ -1,8 +1,7 @@
 package com.hanium.mom4u.domain.scan.registry;
 
 import com.hanium.mom4u.domain.scan.dto.response.ModelResponseDto;
-import com.hanium.mom4u.global.exception.GeneralException;
-import com.hanium.mom4u.global.response.StatusCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Sinks;
 
@@ -15,6 +14,7 @@ import java.util.concurrent.ConcurrentMap;
  * 대기열에 String CorrelationId도 추가하여 고유한 작업에 대하여 처리
  */
 @Component
+@Slf4j
 public class PendingSinkRegistry {
 
     private final ConcurrentMap<String, Sinks.One<ModelResponseDto>> waits = new ConcurrentHashMap<>();
@@ -48,7 +48,7 @@ public class PendingSinkRegistry {
      */
     public void completeTimeout(String correlationId) {
         take(correlationId).ifPresent(sink -> {
-                    throw GeneralException.of(StatusCode.FAILURE_TEST);
+            log.warn("제한 시간에 초과되어 저장소에서 삭제: {}", correlationId);
         });
     }
 }

--- a/src/main/java/com/hanium/mom4u/external/redis/config/RedisConfig.java
+++ b/src/main/java/com/hanium/mom4u/external/redis/config/RedisConfig.java
@@ -43,10 +43,19 @@ public class RedisConfig {
     @Bean
     @Primary
     public RedisTemplate<String, String> redisStringTemplate(LettuceConnectionFactory connectionFactory) {
+
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
+
         template.setKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        template.setDefaultSerializer(new StringRedisSerializer());
+
+        template.afterPropertiesSet();
+
         return template;
     }
 

--- a/src/main/java/com/hanium/mom4u/external/redis/publisher/ImageJobPublisher.java
+++ b/src/main/java/com/hanium/mom4u/external/redis/publisher/ImageJobPublisher.java
@@ -1,15 +1,17 @@
 package com.hanium.mom4u.external.redis.publisher;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hanium.mom4u.external.redis.message.ImageJobMessage;
 import com.hanium.mom4u.external.redis.common.RedisStreamNames;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.RedisStreamCommands;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamRecords;
-import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Mono;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -20,35 +22,53 @@ import java.util.Objects;
 @Slf4j
 public class ImageJobPublisher {
 
-    private final ReactiveStringRedisTemplate reactiveStringRedisTemplate;
+    private final RedisTemplate<String, String> redisStringTemplate;
     private final ObjectMapper objectMapper;
 
+
     /**
-     * Mono 객체를 통한 비동기 발행
-     * ImageJobMessage Redis Stream에 Publish 하기 -> FastAPI에서 구독 후 처리
+     * 동기식으로 Redis Stream(image.jobs)에 작업 발행하기
      * @param imageJobMessage
+     * @return
      */
-    public Mono<RecordId> publish(ImageJobMessage imageJobMessage) {
+    public RecordId publish(ImageJobMessage imageJobMessage) {
 
         // 검증
         Objects.requireNonNull(imageJobMessage, "ImageJobMessage must not be null");
         Objects.requireNonNull(imageJobMessage.getCorrelationId(), "correlationId must not be null");
 
-        // 직렬화 후 XADD로 메시지 발행
-        return Mono.fromCallable(() -> objectMapper.writeValueAsString(imageJobMessage))
-                .map(payload -> {
-                    Map<String, String> fields = new HashMap<>();
-                    fields.put("type", "image_job");
-                    fields.put("correlationId", imageJobMessage.getCorrelationId());
-                    fields.put("payload", payload);
-                    return fields;
-                })
-                .flatMap(fields -> {
-                    var record = StreamRecords.newRecord()
-                            .in(RedisStreamNames.JOB_STREAM)
-                            .ofMap(fields);
-                    return reactiveStringRedisTemplate.opsForStream().add(record);
-                })
-                .onErrorMap(e -> new IllegalStateException("XADD to " + RedisStreamNames.JOB_STREAM + " failed", e));
+        // XADD로 발행하기
+        try {
+            // payload 직렬화
+            String payload = objectMapper.writeValueAsString(imageJobMessage);
+
+            Map<String, String> fields = new HashMap<>();
+            fields.put("type", "image_jobs");
+            fields.put("correlationId", imageJobMessage.getCorrelationId());
+            fields.put("payload", payload);
+
+            // MapRecord 생성
+            MapRecord<String, String, String> record = StreamRecords
+                    .mapBacked(fields)
+                    .withStreamKey(RedisStreamNames.JOB_STREAM);
+
+            // stream 길이 제한 옵션: MAXLEN ~ 10000
+            RedisStreamCommands.XAddOptions options = RedisStreamCommands.XAddOptions.maxlen(10_000).approximateTrimming(true);
+
+            // XADD
+            RecordId id = redisStringTemplate.opsForStream().add(record, options);
+            if (id == null) {
+                throw new IllegalStateException("XADD returned null RecordId");
+            }
+
+            // XADD 성공
+            log.info("XADD OK stream={} id={}", RedisStreamNames.JOB_STREAM, id.getValue());
+            return id;
+
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Failed to serialize ImageJobMessage", e);
+        } catch (Exception e) {
+            throw new IllegalStateException("XADD to " + RedisStreamNames.JOB_STREAM + " failed", e);
+        }
     }
 }

--- a/src/main/java/com/hanium/mom4u/global/config/MvcAsyncConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/MvcAsyncConfig.java
@@ -1,0 +1,14 @@
+package com.hanium.mom4u.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcAsyncConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+            configurer.setDefaultTimeout(180_000L); // TODO: 추후 조정
+    }
+}

--- a/src/main/java/com/hanium/mom4u/global/config/NettyConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/NettyConfig.java
@@ -1,0 +1,24 @@
+package com.hanium.mom4u.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.netty.http.server.HttpServer;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class NettyConfig {
+
+    @Bean
+    public HttpServer httpServer() {
+        return HttpServer.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 180_000) // TODO: 3분에서 조정 필요
+                .doOnConnection(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler(180, TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler(180, TimeUnit.SECONDS))
+                );
+    }
+}

--- a/src/main/java/com/hanium/mom4u/global/config/NettyConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/NettyConfig.java
@@ -3,22 +3,24 @@ package com.hanium.mom4u.global.config;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import reactor.netty.http.server.HttpServer;
-
-import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class NettyConfig {
 
     @Bean
-    public HttpServer httpServer() {
-        return HttpServer.create()
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 180_000) // TODO: 3분에서 조정 필요
-                .doOnConnection(conn -> conn
-                        .addHandlerLast(new ReadTimeoutHandler(180, TimeUnit.SECONDS))
-                        .addHandlerLast(new WriteTimeoutHandler(180, TimeUnit.SECONDS))
-                );
+    public WebServerFactoryCustomizer<NettyReactiveWebServerFactory> nettyCustomizer() {
+        return factory -> factory.addServerCustomizers(http ->
+                http
+                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 180_000) // TODO: 3분에서 조정 필요
+                        .doOnConnection(conn -> conn
+                                .addHandlerLast(new ReadTimeoutHandler(180))
+                                .addHandlerLast(new WriteTimeoutHandler(180))
+                        )
+        );
     }
+
 }


### PR DESCRIPTION
## 📌 작업 목적
- 이미지 분석에 대한 Job 발행 부분이 제대로 저장되지 않는 오류를 수정하였습니다.
- 타임아웃에 대한 예외처리를 중복되지 않도록 설정하였습니다.
- connection이 끊기는 부분을 수정하였습니다.

---

## 🗂 작업 유형
- [x] 버그 수정 (Bug Fix)

---

## 🔨 주요 작업 내용
- **`ImageJobPublisher.class`**
```java
            // stream 길이 제한 옵션: MAXLEN ~ 10000
            RedisStreamCommands.XAddOptions options = RedisStreamCommands.XAddOptions.maxlen(10_000).approximateTrimming(true);

            // XADD
            RecordId id = redisStringTemplate.opsForStream().add(record, options);
            if (id == null) {
                throw new IllegalStateException("XADD returned null RecordId");
            }

            // XADD 성공
            log.info("XADD OK stream={} id={}", RedisStreamNames.JOB_STREAM, id.getValue());
            return id;
```
- 기존의 Consumer가 ReactiveRedis를 기반으로 작업하던 것에 맞춰 ImagePublisher도 Mono로 작업하였었습니다
- 그런데, 하나의 API 내에서 Mono로 발행을 대기하는 경우, 응답을 받을 때까지 블로킹되는 특성 때문에 실제 발행이 이뤄지지 않는 문제가 발생했습니다 (Mono 특징)
- Mono와 같은 비동기 대신 동기 식 발행으로 변경하였습니다 (XADD 직접 실행)
- WebFlux에 대한 지식 부족으로 인해서 일어난 오류였습니다 😅

<br>

- **`RedisConfig.class`**
```java
    @Bean
    @Primary
    public RedisTemplate<String, String> redisStringTemplate(LettuceConnectionFactory connectionFactory) {

        RedisTemplate<String, String> template = new RedisTemplate<>();
        template.setConnectionFactory(connectionFactory);

        template.setKeySerializer(new StringRedisSerializer());
        template.setValueSerializer(new StringRedisSerializer());
        template.setHashKeySerializer(new StringRedisSerializer());
        template.setHashValueSerializer(new StringRedisSerializer());

        template.setDefaultSerializer(new StringRedisSerializer());

        template.afterPropertiesSet();

        return template;
    }
```
- 동기식으로 이루어진 Redis에 대하여 XADD로 발행을 하면 직렬화가 제대로 되지 않아서 fast API 서버에서 받아들이지 못했습니다
- kye와 value에 대해서만 직렬화를 적용하고, HashKey에 대한 적용은 하지 않아서 일어난 일이었습니다 (Message에 대한 Record는 HashKey를 기반으로 작동 )
- 각각 모든 값에 StringRedisSerializer를 적용하여 성공적으로 직렬화에 성공하였고 인식 잘 됩니다

<br>

- **`FileStorageService.class`**
```java
    public String generatePresignedGetUrl(String objectKey) {
        S3Presigner presigner;
// ...
        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
                .getObjectRequest(getObjectRequest)
                .signatureDuration(Duration.ofMinutes(3))
                .build();

```
- 다운로드에는 Get이 필요하므로 추가해두었습니다

<br>
<br>

---

## 🌋 트러블 슈팅

- **`NettyConfig.class`**
```java
@Configuration
public class NettyConfig {

    @Bean
    public HttpServer httpServer() {
        return HttpServer.create()
                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 180_000) // TODO: 3분에서 조정 필요
                .doOnConnection(conn -> conn
                        .addHandlerLast(new ReadTimeoutHandler(180, TimeUnit.SECONDS))
                        .addHandlerLast(new WriteTimeoutHandler(180, TimeUnit.SECONDS))
                );
    }
}
```
- timeout 설정한 것보다 훨씬 짧게 api 응답이 종료되어서 WebFlux에 대한 전체 타임아웃을 일단 임으로 조정하였습니다

<br>

- **`MvcAsyncConfig.class`**
```java
@Configuration
public class MvcAsyncConfig implements WebMvcConfigurer {

    @Override
    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
            configurer.setDefaultTimeout(180_000L); // TODO: 추후 조정
    }
}
```
- 그래도 계속 API가 응답 듣기도 전에 종료가 되는 문제 발생했습니다
- WebFlux 기반의 API는 Spring Web MVC가 DeferredResult와 같은 비동기로 인식하고 처리 하는 중이었습니다(원인)
- 애초에 DeferredResult를 실제로 사용하는 것도 아니고 이에 대하여 제대로 타임아웃 설정이 안되니 기본 WebMVC의 커넥션 시간으로 적용되어 API가 30초 후에 종료
- 그래서 WebMvcConfigure 구현체로 새로 비동기에 대한 시간 설정을 기본으로 3분으로 설정하였습니다
- 아직 실제 저희 모델의 속도를 몰라서 (GPU 적용) 일단 3분 설정했습니다!!!

<br>
<br>

---

## 🧪 테스트 결과

- 이미지 요청 후 FastAPI에서 처리 후 응답 확인 ( 제 컴퓨터가 불타가면서 테스트했어요 😆 )
<img width="1087" height="1038" alt="image" src="https://github.com/user-attachments/assets/cfaaca45-876d-4f07-86bf-f01afbec78c5" />

- Fast API에서도 인코딩 등 잘 되는 것 확인했습니다
<img width="304" height="187" alt="image" src="https://github.com/user-attachments/assets/476632a9-13ec-4c42-9096-f84ad45153e3" />


---

## 📎 관련 이슈
- Closes #89 

---

## 💬 논의 및 고민한 점
- 서버 배포해보고 모델에 대한 응답 시간 확인 후에 시간 조정에 대하여 변경하면 좋을 것 같습니다
- Redis Stream에서 처리하지 못한 작업에 대한 예외 처리를 확실하게 하는 걸 다음 이슈로 올리겠습니다

---