### PR TITLE
[FIX] Multipartfile 업로드 실패 해결

### DIFF
--- a/nginx/nginx.blue.conf
+++ b/nginx/nginx.blue.conf
@@ -7,11 +7,29 @@ server {
     listen [::]:80;
     server_name backend;
 
+    client_max_body_size 50m;
+
+    client_body_timeout 60s;
+    client_body_buffer_size 256k;
+
     location / {
         proxy_pass http://app;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+
+        proxy_set_header Content-Type $content_type;
+        proxy_set_header Content-Length & content_length;
+
+        proxy_set_header Host                $host;
+        proxy_set_header X-Real-IP           $remote_addr;
+        proxy_set_header X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto   $scheme;
+
+        # 요청/응답 버퍼링: 호환성 우선
+        proxy_request_buffering on;
+        proxy_buffering on;
+
+        proxy_read_timeout 180s;
+        proxy_send_timeout 180s;
     }
 }

--- a/nginx/nginx.green.conf
+++ b/nginx/nginx.green.conf
@@ -7,11 +7,29 @@ server {
     listen [::]:80;
     server_name backend;
 
+    client_max_body_size 50m;
+
+    client_body_timeout 60s;
+    client_body_buffer_size 256k;
+
     location / {
         proxy_pass http://app;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+
+        proxy_set_header Content-Type $content_type;
+        proxy_set_header Content-Length & content_length;
+
+        proxy_set_header Host                $host;
+        proxy_set_header X-Real-IP           $remote_addr;
+        proxy_set_header X-Forwarded-For     $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto   $scheme;
+
+        # 요청/응답 버퍼링: 호환성 우선
+        proxy_request_buffering on;
+        proxy_buffering on;
+
+        proxy_read_timeout 180s;
+        proxy_send_timeout 180s;
     }
 }

--- a/src/main/java/com/hanium/mom4u/domain/scan/controller/ScanController.java
+++ b/src/main/java/com/hanium/mom4u/domain/scan/controller/ScanController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,12 +30,12 @@ public class ScanController {
     private final ScanService scanService;
     private final PendingSinkRegistry registry;
 
-    @PostMapping
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "스캔 요청 API", description = """
             사진 파일을 업로드해주세요. png와 jpeg 확장자가 아니면 제외됩니다.
             """)
     public Mono<ResponseEntity<CommonResponse<ModelResponseDto>>> scan(
-            @RequestParam("file") MultipartFile file) throws IOException {
+            @RequestPart("file") MultipartFile file) throws IOException {
 
         String correlationId = scanService.sendImageToS3(file);
 


### PR DESCRIPTION
## 📌 작업 목적
- 서버 상에 RequestParam으로 지정한 MultiPart 파일이 올라가지 않는 문제 해결 위해 변경

---

## 🗂 작업 유형
> 해당하는 항목 모두 체크
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 리팩터링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포/환경 설정 (Chore)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용
- RequestParam에서 RequestPart로 수정
```java
    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
    @Operation(summary = "스캔 요청 API", description = """
            사진 파일을 업로드해주세요. png와 jpeg 확장자가 아니면 제외됩니다.
            """)
    public Mono<ResponseEntity<CommonResponse<ModelResponseDto>>> scan(
            @RequestPart("file") MultipartFile file) throws IOException {

```
- `@RequestParam` : 주로 단순한 데이터나 key-value 쌍을 처리합니다. GET 요청의 쿼리 파라미터나 POST 요청의 form-urlencoded 데이터를 바인딩할 때 사용됩니다.
- `@RequestPart`: multipart/form-data 형식의 데이터를 처리하는 데 사용됩니다. 주로 파일 업로드와 같은 복잡한 데이터를 다룰 때 사용됩니다.

<br>


- Nginx.conf 수정
```conf
        proxy_http_version 1.1;
        
        proxy_set_header Content-Type $content_type;
        proxy_set_header Content-Length & content_length;

```
- 프록시에서 content_type을 건드리지 않도록 지정

---

## 📎 관련 이슈
- Closes #93 

---

