### PR TITLE
[FEATURE] ThreadPoolTaskExecutor 기반 작업 변경

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,8 +54,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/docker/
-          target: /home/ubuntu/dearbelly-api/
+          source: ./deploy/docker/*
+          target: /home/ubuntu/dearbelly-api/docker/
 
       - name: Transfer nginx file to ec2
         uses: appleboy/scp-action@master
@@ -63,8 +63,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/nginx/
-          target: /home/ubuntu/
+          source: ./deploy/nginx/*
+          target: /home/ubuntu/nginx/
 
       - name: Transfer monitoring file to ec2
         uses: appleboy/scp-action@master
@@ -72,8 +72,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/monitoring/
-          target: /home/ubuntu/
+          source: ./deploy/monitoring/*
+          target: /home/ubuntu/monitoring/
 
   deploy:
     runs-on: ubuntu-22.04

--- a/src/main/java/com/hanium/mom4u/domain/family/service/FamilyResetScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/service/FamilyResetScheduler.java
@@ -6,6 +6,7 @@ import com.hanium.mom4u.domain.member.entity.Member;
 import com.hanium.mom4u.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,6 +23,7 @@ public class FamilyResetScheduler {
     private final MemberRepository memberRepository;
 
     // 실제 운영용: 매일 자정(00:00) 실행
+    @Async("schedulerExecutor")
     @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
     public void resetOldFamilies() {

--- a/src/main/java/com/hanium/mom4u/domain/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/scheduler/MemberCleanupScheduler.java
@@ -7,6 +7,7 @@ import com.hanium.mom4u.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ public class MemberCleanupScheduler {
     private final BabyRepository babyRepository;
 
     // 매일 12시 정각 실행
+    @Async("schedulerExecutor")
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void deleteInactiveMembersAfter7Days() {

--- a/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
@@ -1,6 +1,5 @@
 package com.hanium.mom4u.domain.news.listener;
 
-import com.hanium.mom4u.domain.news.listener.S3JsonImportEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,9 +18,10 @@ public class NewsScheduler {
 
     private final ApplicationEventPublisher eventPublisher;
 
+    @Async("schedulerExecutor")
     @Scheduled(cron = "0 0 4 * * *") // 새벽 4시에 실행
     public void triggerEvent() {
-        log.info("Event started");
+        log.info("S3 Importing Event started");
         eventPublisher.publishEvent(new S3JsonImportEvent(this, BUCKET_NAME));
     }
 }

--- a/src/main/java/com/hanium/mom4u/external/s3/event/S3DeleteEventListener.java
+++ b/src/main/java/com/hanium/mom4u/external/s3/event/S3DeleteEventListener.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -11,7 +12,6 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 @Component
 @RequiredArgsConstructor
-@EnableAsync
 @Slf4j
 public class S3DeleteEventListener {
 
@@ -21,6 +21,7 @@ public class S3DeleteEventListener {
     private final S3Client s3Client;
 
     @EventListener
+    @Async("asyncExecutor")
     public void onS3DeleteEvent(S3DeleteEvent event) {
 
         DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()

--- a/src/main/java/com/hanium/mom4u/global/config/AsyncConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/AsyncConfig.java
@@ -1,0 +1,72 @@
+package com.hanium.mom4u.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.concurrent.*;
+
+@Configuration
+@Slf4j
+public class AsyncConfig {
+
+    private static int CORE_POOL_SIZE = 30;
+    private static int MAX_POOL_SIZE = 50;
+    private static int QUEUE_CAPACITY = 200;
+    private static int AWAIT_TERMINATION_SECONDS = 60;
+
+    /**
+     * 일반 Async용 스레드
+     * @return
+     */
+    @Bean("asyncExecutor")
+    public ThreadPoolTaskExecutor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+
+        // Queue 대기열 가득 차서 ThreadPoolExecutor 직접 실행
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        executor.setThreadNamePrefix("Async-exec-");
+
+        // 종료 시 대기 및 정리
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Scheduler 용 Async
+     * @return
+     */
+    @Bean(name = "schedulerExecutor")
+    public ThreadPoolTaskScheduler asyncSchedulerExecutor() {
+        ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
+        executor.setPoolSize(CORE_POOL_SIZE);
+
+        executor.setRemoveOnCancelPolicy(true);
+        executor.setThreadNamePrefix("Async-sche-");
+
+        // 예외 시
+        executor.setErrorHandler(t -> {
+            log.error("Async executor error", t);
+                }
+        );
+
+        // 종료
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+
+        executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## 📌 작업 목적

- 메인 스레드에 대한 점유율을 낮추기 위하여 스케줄링과 event 기반들은 별도의 스레드로 비동기를 적용하도록 하였습니다.

---

## 🗂 작업 유형
- [ ] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 리팩터링 (Refactor)
- [x] 성능 개선 (Performance)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포/환경 설정 (Chore)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

- **`AsyncConfig`**
```java
@Configuration
@Slf4j
public class AsyncConfig {

    private static int CORE_POOL_SIZE = 30;
    private static int MAX_POOL_SIZE = 50;
    private static int QUEUE_CAPACITY = 200;
    private static int AWAIT_TERMINATION_SECONDS = 60;
```
- 각각의 기본은 다음과 같이 설정하였습니다.
- CORE_POOL_SIZE: 기본적으로 유지되는 스레드의 수(우선은 넉넉하게 잡았습니다)
- MAX_POOL_SIZE: 대기 큐가 찼을 때의 수
- QUEUE_CAPACITY : 스레드가 처리 중일 때 추가로 대기 시킬 수 있는 작업의 개수로 이를 넘으면 큐가 가득차서 거부정책 실행 ( `CalllerRunsPolicy` 실행 ) , 근데 너무 크면 oom문제 때문에 서비스 도중 절충 더 필요하면 수정하겠습니다!

<br>

- 일반 `asyncExecutor`
```java
    @Bean("asyncExecutor")
    public ThreadPoolTaskExecutor asyncExecutor() {
        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
// 생략

        // Queue 대기열 가득 차서 ThreadPoolExecutor 직접 실행
        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());

        executor.setThreadNamePrefix("Async-exec-");

        // 종료 시 대기 및 정리
        executor.setWaitForTasksToCompleteOnShutdown(true);
```
- 일반적인 비동기 작업에서의 스레드 풀로 설정하였습니다.
- CallerRunsPolicy를 통하여 새로운 스레드를 만들지 않고 요청을 보낸 스레드가 직접 생성해서 과부에 대한 처리 추가했습니다
- waitForTaskToCompleteOnShutdown을 통하여 애플리케이션이 종료 중에 다음 작업이 실행 중이면 기다리도록 하여 DB 작업에 영향이 안가도록 하였습니다

<img width="584" height="44" alt="image" src="https://github.com/user-attachments/assets/41df303b-5a08-4af1-8ad7-66b7d0854fc8" />


<br><br>

- 스케줄러 용 `schedulerExecutor`
```java
    @Bean(name = "schedulerExecutor")
    public ThreadPoolTaskScheduler asyncSchedulerExecutor() {
        ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
// 생략
        executor.setRemoveOnCancelPolicy(true);
        executor.setThreadNamePrefix("Async-sche-");

        // 예외 시
        executor.setErrorHandler(t -> {
            log.error("Async executor error", t);
                }
        );

        // 종료
        executor.setWaitForTasksToCompleteOnShutdown(true);
        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);

        executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
```
- 스케줄링 작업들은 해당 작업을 실행하도록 ThreadPoolTaskScheduler에 대한 설정 추가
- cancel에 대하여 true로 하여 취소 작업이 큐에 있으면 제거 하도록 설정
- 에러 시 우선은 추가로 로깅하도록 설정하였습니다
- 여기에도 종료 시 대기 후에 종료하도록 설정했으나 대기 시간 내에 처리하지 못할 시에 종료하도록 설정했습니다 (AWAIT_TERMINATION_SECONDS 만큼 기다림)
- 종료 직전 큐에 쌓여있던 지연에 대하여 실행 여부에 대해서는 false로 설정했습니다!


---

## 📎 관련 이슈
- Closes #105 

---

## 💬 논의 및 고민한 점
- 저희 스케줄러 이거밖에 없겠죠??

---

