### PR TITLE
[FEATURE] Jacoco 라이브러리를 통한 테스트 커버리지 확인

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,8 +54,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/docker/
-          target: /home/ubuntu/dearbelly-api/
+          source: ./deploy/docker/*
+          target: /home/ubuntu/dearbelly-api/docker/
 
       - name: Transfer nginx file to ec2
         uses: appleboy/scp-action@master
@@ -63,8 +63,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/nginx/
-          target: /home/ubuntu/
+          source: ./deploy/nginx/*
+          target: /home/ubuntu/nginx/
 
       - name: Transfer monitoring file to ec2
         uses: appleboy/scp-action@master
@@ -72,8 +72,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/monitoring/
-          target: /home/ubuntu/
+          source: ./deploy/monitoring/*
+          target: /home/ubuntu/monitoring/
 
   deploy:
     runs-on: ubuntu-22.04

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.4.5'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
+    id 'org.asciidoctor.jvm.convert' version '4.0.2'
 }
 
 group = 'com.hanium'
@@ -13,10 +15,16 @@ java {
     }
 }
 
+jacoco {
+    toolVersion = "0.8.13"
+    reportsDirectory = layout.buildDirectory.dir("reports/jacoco")
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -41,14 +49,14 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // REST docs
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // Asciidoctor 문서 변환
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
     // H2
     testImplementation 'com.h2database:h2:2.1.214'
-
-    // Webflux
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-
-    // thymeleaf
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -89,8 +97,76 @@ dependencies {
     implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
+// Jacoco 제외 대상 설정
+def snippetsDir = layout.buildDirectory.dir("generated-snippets")
+ext.jacocoExclusions = [
+        '**/*Dto*.class',
+        '**/dto/**',
+        '**/Q*.class'
+]
+
 tasks.named('test') {
     useJUnitPlatform()
+    outputs.dir(snippetsDir)
+    finalizedBy(tasks.named('jacocoTestReport'))
+    finalizedBy(tasks.named('jacocoTestCoverageVerification'))
+}
+
+tasks.named('jacocoTestReport') {
+
+    classDirectories.setFrom(
+            files(classDirectories.files.collect { dir ->
+                fileTree(dir: dir, exclude: jacocoExclusions)
+            })
+    )
+
+    dependsOn(tasks.named('test'))
+    reports {
+        xml.required = false
+        csv.required = false
+        html.required = true
+        html.outputLocation.set(layout.buildDirectory.dir("reports/jacoco/html"))
+    }
+}
+
+tasks.named('jacocoTestCoverageVerification') {
+    dependsOn(tasks.named('jacocoTestReport'))
+
+    classDirectories.setFrom(
+            files(tasks.named('jacocoTestReport').get().classDirectories.files.collect { dir ->
+                fileTree(dir: dir, exclude: jacocoExclusions)
+            })
+    )
+
+    // Test Coverage 설정
+//    violationRules {
+//        rule {
+//            element = 'BUNDLE'
+//            limit {
+//                counter = 'LINE'
+//                value   = 'COVEREDRATIO'
+//                minimum = 0.40
+//            }
+//            limit {
+//                counter = 'BRANCH'
+//                value   = 'COVEREDRATIO'
+//                minimum = 0.40
+//            }
+//        }
+//    }
+}
+
+tasks.named('asciidoctor') {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn tasks.named('test')
+}
+
+tasks.named('bootJar') {
+    dependsOn tasks.named('asciidoctor')
+    from(layout.buildDirectory.dir("docs/asciidoc")) {
+        into "static/docs"
+    }
 }
 
 def queryDslSrcDir = 'build/generated/querydsl/'

--- a/src/main/java/com/hanium/mom4u/domain/member/scheduler/MemberCleanupScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/scheduler/MemberCleanupScheduler.java
@@ -7,6 +7,7 @@ import com.hanium.mom4u.domain.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,7 @@ public class MemberCleanupScheduler {
     private final BabyRepository babyRepository;
 
     // 매일 12시 정각 실행
+    @Async("schedulerExecutor")
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void deleteInactiveMembersAfter7Days() {

--- a/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
@@ -1,6 +1,5 @@
 package com.hanium.mom4u.domain.news.listener;
 
-import com.hanium.mom4u.domain.news.listener.S3JsonImportEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,9 +18,10 @@ public class NewsScheduler {
 
     private final ApplicationEventPublisher eventPublisher;
 
+    @Async("schedulerExecutor")
     @Scheduled(cron = "0 0 4 * * *") // 새벽 4시에 실행
     public void triggerEvent() {
-        log.info("Event started");
+        log.info("S3 Importing Event started");
         eventPublisher.publishEvent(new S3JsonImportEvent(this, BUCKET_NAME));
     }
 }

--- a/src/main/java/com/hanium/mom4u/external/s3/event/S3DeleteEventListener.java
+++ b/src/main/java/com/hanium/mom4u/external/s3/event/S3DeleteEventListener.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -11,7 +12,6 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 @Component
 @RequiredArgsConstructor
-@EnableAsync
 @Slf4j
 public class S3DeleteEventListener {
 
@@ -21,6 +21,7 @@ public class S3DeleteEventListener {
     private final S3Client s3Client;
 
     @EventListener
+    @Async("asyncExecutor")
     public void onS3DeleteEvent(S3DeleteEvent event) {
 
         DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()

--- a/src/main/java/com/hanium/mom4u/global/config/AsyncConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/config/AsyncConfig.java
@@ -1,0 +1,72 @@
+package com.hanium.mom4u.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.concurrent.*;
+
+@Configuration
+@Slf4j
+public class AsyncConfig {
+
+    private static int CORE_POOL_SIZE = 30;
+    private static int MAX_POOL_SIZE = 50;
+    private static int QUEUE_CAPACITY = 200;
+    private static int AWAIT_TERMINATION_SECONDS = 60;
+
+    /**
+     * 일반 Async용 스레드
+     * @return
+     */
+    @Bean("asyncExecutor")
+    public ThreadPoolTaskExecutor asyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+
+        // Queue 대기열 가득 차서 ThreadPoolExecutor 직접 실행
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
+        executor.setThreadNamePrefix("Async-exec-");
+
+        // 종료 시 대기 및 정리
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+
+        executor.initialize();
+        return executor;
+    }
+
+    /**
+     * Scheduler 용 Async
+     * @return
+     */
+    @Bean(name = "schedulerExecutor")
+    public ThreadPoolTaskScheduler asyncSchedulerExecutor() {
+        ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
+        executor.setPoolSize(CORE_POOL_SIZE);
+
+        executor.setRemoveOnCancelPolicy(true);
+        executor.setThreadNamePrefix("Async-sche-");
+
+        // 예외 시
+        executor.setErrorHandler(t -> {
+            log.error("Async executor error", t);
+                }
+        );
+
+        // 종료
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+
+        executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/test/java/com/hanium/mom4u/Mom4uApplicationTest.java
+++ b/src/test/java/com/hanium/mom4u/Mom4uApplicationTest.java
@@ -2,9 +2,6 @@ package com.hanium.mom4u;
 
 import org.springframework.boot.test.context.SpringBootTest;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
 class Mom4uApplicationTest {
-
 }


### PR DESCRIPTION
## 📌 작업 목적
- 테스트 커버리지 확인을 위한 Jacoco 의존성을 추가하였습니다.

---

## 🗂 작업 유형
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 리팩터링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가/수정 (Test)
- [x] 빌드/배포/환경 설정 (Chore)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

- 우선은 빌드 성공을 위해 주석처리를 하였습니다
```
tasks.named('jacocoTestCoverageVerification') {
    dependsOn(tasks.named('jacocoTestReport'))

    classDirectories.setFrom(
            files(tasks.named('jacocoTestReport').get().classDirectories.files.collect { dir ->
                fileTree(dir: dir, exclude: jacocoExclusions)
            })
    )

    // Test Coverage 설정
//    violationRules {
//        rule {
//            element = 'BUNDLE'
//            limit {
//                counter = 'LINE'
//                value   = 'COVEREDRATIO'
//                minimum = 0.40
//            }
//            limit {
//                counter = 'BRANCH'
//                value   = 'COVEREDRATIO'
//                minimum = 0.40
//            }
//        }
//    }
}
```
- 회의 때 나눴던 것처럼 프로덕션 배포까지 40%는 통과되는 형식으로 CI 구축하는 것을 목표로 하면 될 것 같습니다(1차 목표)

<br><br>

- 추가로 REST Docs에 대해서도 추가는 해두었는데, WebMVC에 대한 테스트 코드 작성이 다소 어려워서 이 쪽은 시간이 좀 소요될 것 같으니 따로 이슈 생성하도록 하겠습니다( 진작 해둘걸,,, 🤣 )
```
tasks.named('test') {
    useJUnitPlatform()
    outputs.dir(snippetsDir)
    finalizedBy(tasks.named('jacocoTestReport'))
    finalizedBy(tasks.named('jacocoTestCoverageVerification'))
}
```
- test를 실행할 시에 설정해둔 경로로 html 결과가 생성됩니다 ( "reports/jacoco/html" )

<br>

---

## 📎 관련 이슈
- Closes #108 

---

## 💬 논의 및 고민한 점
- 할 수 있다

---
