### PR TITLE
[REFACTOR] 회원/비회원 구분 및 에러 응답 개선

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
@@ -23,7 +23,6 @@ public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "월별 일정 조회", description = "사용자의 특정 연도/월에 해당하는 모든 일정을 조회합니다.")
     @GetMapping("/monthly")
     public ResponseEntity<?> getMonthlySchedules(
@@ -34,7 +33,6 @@ public class ScheduleController {
         return ResponseEntity.ok(CommonResponse.onSuccess(schedules));
     }
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일별 일정 조회", description = "사용자의 특정 날짜에 해당하는 모든 일정을 조회합니다.")
     @GetMapping("/daily")
     public ResponseEntity<?> getDailySchedules(
@@ -44,7 +42,6 @@ public class ScheduleController {
         return ResponseEntity.ok(CommonResponse.onSuccess(schedules));
     }
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 등록", description = "사용자의 새 일정을 생성합니다.")
     @PostMapping
     public ResponseEntity<?> createSchedule(@RequestBody ScheduleRequest request) {
@@ -52,21 +49,18 @@ public class ScheduleController {
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 수정", description = "지정한 ID의 일정을 수정합니다.")
     @PatchMapping("/{scheduleId}")
     public ResponseEntity<?> updateSchedule(@PathVariable Long scheduleId, @RequestBody ScheduleRequest request) {
         scheduleService.updateSchedule(scheduleId, request);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 삭제", description = "지정한 ID의 일정을 삭제합니다.")
     @DeleteMapping("/{scheduleId}")
     public ResponseEntity<?> deleteSchedule(@PathVariable Long scheduleId) {
         scheduleService.deleteSchedule(scheduleId);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 상세 조회", description = "지정한 ID의 일정 정보를 상세 조회합니다.")
     @GetMapping("/{scheduleId}")
     public ResponseEntity<?> getScheduleDetail(@PathVariable Long scheduleId) {

--- a/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
+++ b/src/main/java/com/hanium/mom4u/domain/calendar/controller/ScheduleController.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -23,6 +23,7 @@ public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "월별 일정 조회", description = "사용자의 특정 연도/월에 해당하는 모든 일정을 조회합니다.")
     @GetMapping("/monthly")
     public ResponseEntity<?> getMonthlySchedules(
@@ -33,6 +34,7 @@ public class ScheduleController {
         return ResponseEntity.ok(CommonResponse.onSuccess(schedules));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일별 일정 조회", description = "사용자의 특정 날짜에 해당하는 모든 일정을 조회합니다.")
     @GetMapping("/daily")
     public ResponseEntity<?> getDailySchedules(
@@ -42,6 +44,7 @@ public class ScheduleController {
         return ResponseEntity.ok(CommonResponse.onSuccess(schedules));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 등록", description = "사용자의 새 일정을 생성합니다.")
     @PostMapping
     public ResponseEntity<?> createSchedule(@RequestBody ScheduleRequest request) {
@@ -49,20 +52,21 @@ public class ScheduleController {
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
 
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 수정", description = "지정한 ID의 일정을 수정합니다.")
     @PatchMapping("/{scheduleId}")
     public ResponseEntity<?> updateSchedule(@PathVariable Long scheduleId, @RequestBody ScheduleRequest request) {
         scheduleService.updateSchedule(scheduleId, request);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 삭제", description = "지정한 ID의 일정을 삭제합니다.")
     @DeleteMapping("/{scheduleId}")
     public ResponseEntity<?> deleteSchedule(@PathVariable Long scheduleId) {
         scheduleService.deleteSchedule(scheduleId);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "일정 상세 조회", description = "지정한 ID의 일정 정보를 상세 조회합니다.")
     @GetMapping("/{scheduleId}")
     public ResponseEntity<?> getScheduleDetail(@PathVariable Long scheduleId) {

--- a/src/main/java/com/hanium/mom4u/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/controller/FamilyController.java
@@ -19,7 +19,6 @@ import java.util.List;
 public class FamilyController {
     private final FamilyService familyService;
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "가족 코드 생성 API", description = "임산부만 호출할 수 있으며, 3분 유효한 공유 코드를 생성합니다.")
     @PostMapping("/api/v1/family-code")
     public ResponseEntity<CommonResponse> generateFamilyCode() {
@@ -27,7 +26,6 @@ public class FamilyController {
         return ResponseEntity.ok(CommonResponse.onSuccess(code));
     }
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "가족 참여 API", description = "가족 코드를 입력해 3분 내 공유에 참여합니다.")
     @PostMapping("/api/v1/family-code/join")
     public ResponseEntity<CommonResponse> joinFamily(@RequestBody FamilyCodeRequest request){
@@ -35,7 +33,6 @@ public class FamilyController {
         return ResponseEntity.ok(CommonResponse.onSuccess("참여 성공"));
     }
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "가족 코드 유효성 확인 + 사용자 목록 조회", description = "가족 코드가 유효한 경우 사용자 목록 반환. 유효하지 않으면 예외 발생")
     @GetMapping("/api/v1/family-code/members")
     public ResponseEntity<CommonResponse> getFamilyMembers() {

--- a/src/main/java/com/hanium/mom4u/domain/family/controller/FamilyController.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/controller/FamilyController.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,6 +19,7 @@ import java.util.List;
 public class FamilyController {
     private final FamilyService familyService;
 
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "가족 코드 생성 API", description = "임산부만 호출할 수 있으며, 3분 유효한 공유 코드를 생성합니다.")
     @PostMapping("/api/v1/family-code")
     public ResponseEntity<CommonResponse> generateFamilyCode() {
@@ -26,6 +27,7 @@ public class FamilyController {
         return ResponseEntity.ok(CommonResponse.onSuccess(code));
     }
 
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "가족 참여 API", description = "가족 코드를 입력해 3분 내 공유에 참여합니다.")
     @PostMapping("/api/v1/family-code/join")
     public ResponseEntity<CommonResponse> joinFamily(@RequestBody FamilyCodeRequest request){
@@ -33,15 +35,12 @@ public class FamilyController {
         return ResponseEntity.ok(CommonResponse.onSuccess("참여 성공"));
     }
 
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "가족 코드 유효성 확인 + 사용자 목록 조회", description = "가족 코드가 유효한 경우 사용자 목록 반환. 유효하지 않으면 예외 발생")
     @GetMapping("/api/v1/family-code/members")
     public ResponseEntity<CommonResponse> getFamilyMembers() {
         List<FamilyMemberResponse> members = familyService.getFamilyMembersByFamily();
         return ResponseEntity.ok(CommonResponse.onSuccess(members));
     }
-
-
-
 
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,6 +18,7 @@ public class BabyController {
 
     private final BabyService babyService;
 
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "태아 정보 저장 API", description = """
             태아의 정보를 저장하는 API입니다.<br>
             같은 가족일 경우에 공유가 가능합니다.
@@ -29,7 +31,7 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.saveBaby(requestDto))
         );
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "태아 정보 수정 API", description = """
             태아의 정보를 수정하는 API입니다.<br>
             같은 가족일 경우에 공유가 가능합니다.
@@ -43,7 +45,7 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.updateBaby(babyId, requestDto))
         );
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "등록된 태아 정보 전체 조회 API", description = """
             가족 구성원 간에 등록된 태아 전체를 조회합니다.<br>
             """)
@@ -53,7 +55,7 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.readAllBabyInfo())
         );
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "특정 태아 정보 조회하기 API", description = """
             특정 태아의 정보만 조회하는 API입니다.<br>
             """)
@@ -63,7 +65,7 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.readBabyInfo(babyId))
         );
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "특정 태아의 정보 삭제 API", description = """
             특정 태아를 삭제하는 API입니다.<br>
             같은 가족일 경우에 공유가 가능합니다.

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/BabyController.java
@@ -18,7 +18,6 @@ public class BabyController {
 
     private final BabyService babyService;
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "태아 정보 저장 API", description = """
             태아의 정보를 저장하는 API입니다.<br>
             같은 가족일 경우에 공유가 가능합니다.
@@ -31,7 +30,6 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.saveBaby(requestDto))
         );
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "태아 정보 수정 API", description = """
             태아의 정보를 수정하는 API입니다.<br>
             같은 가족일 경우에 공유가 가능합니다.
@@ -45,7 +43,6 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.updateBaby(babyId, requestDto))
         );
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "등록된 태아 정보 전체 조회 API", description = """
             가족 구성원 간에 등록된 태아 전체를 조회합니다.<br>
             """)
@@ -55,7 +52,6 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.readAllBabyInfo())
         );
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "특정 태아 정보 조회하기 API", description = """
             특정 태아의 정보만 조회하는 API입니다.<br>
             """)
@@ -65,7 +61,6 @@ public class BabyController {
                 CommonResponse.onSuccess(babyService.readBabyInfo(babyId))
         );
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "특정 태아의 정보 삭제 API", description = """
             특정 태아를 삭제하는 API입니다.<br>
             같은 가족일 경우에 공유가 가능합니다.

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
@@ -25,7 +25,6 @@ public class MemberController {
 
     private final MemberService memberService;
 
-    @PreAuthorize("hasRole('USER')")
     @PostMapping("/profile")
     @Operation(summary = "회원정보 등록", description = "닉네임, 임신 상태, 출산 예정일 등 기본 정보를 등록합니다.")
     public ResponseEntity<CommonResponse<Void>> updateProfile(
@@ -42,21 +41,18 @@ public class MemberController {
         memberService.updateProfile(nickname, isPregnant, lmpDate, prePregnant, gender, birth, categories);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "프로필 이미지 Presigned URL 발급", description = "이미지를 업로드할 S3 presigned URL을 발급합니다.")
     @GetMapping("/profile/upload-url")
     public ResponseEntity<CommonResponse<String>> getPresignedUploadUrl(@RequestParam String filename) {
         String presignedUrl = memberService.getPresignedUploadUrl(filename);
         return ResponseEntity.ok(CommonResponse.onSuccess(presignedUrl));
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "프로필 이미지 저장", description = "이미지 업로드 후(프론트에서 put해야함) URL을 사용자 정보에 반영합니다.")
     @PatchMapping("/profile/image")
     public ResponseEntity<CommonResponse<Void>> updateProfileImage(@RequestParam("imgUrl") String imgUrl) {
         memberService.updateProfileImage(imgUrl);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "회원 닉네임, 출산예정일, 이미지 수정", description = "마이페이지에서 닉네임, 출산 예정일, 프로필 이미지를 수정합니다.")
     @PatchMapping("/profile/edit")
     public ResponseEntity<CommonResponse<Void>> editProfile(@RequestBody ProfileEditRequest request) {
@@ -64,15 +60,12 @@ public class MemberController {
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
 
-
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "회원정보 조회", description = "현재 로그인한 회원 정보를 조회합니다.")
     @GetMapping("/profile")
     public ResponseEntity<CommonResponse> getMyProfile() {
         return ResponseEntity.ok(CommonResponse.onSuccess(memberService.getMyProfile()));
     }
 
-    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "관심 카테고리 변경(단독)", description = "다른 필드 건드리지 않고 관심 카테고리만 교체합니다.")
     @PatchMapping("/profile/categories")
     public ResponseEntity<CommonResponse<Void>> updateCategories(@RequestBody CategoryUpdateRequest req) {

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -24,6 +25,7 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/profile")
     @Operation(summary = "회원정보 등록", description = "닉네임, 임신 상태, 출산 예정일 등 기본 정보를 등록합니다.")
     public ResponseEntity<CommonResponse<Void>> updateProfile(
@@ -40,21 +42,21 @@ public class MemberController {
         memberService.updateProfile(nickname, isPregnant, lmpDate, prePregnant, gender, birth, categories);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "프로필 이미지 Presigned URL 발급", description = "이미지를 업로드할 S3 presigned URL을 발급합니다.")
     @GetMapping("/profile/upload-url")
     public ResponseEntity<CommonResponse<String>> getPresignedUploadUrl(@RequestParam String filename) {
         String presignedUrl = memberService.getPresignedUploadUrl(filename);
         return ResponseEntity.ok(CommonResponse.onSuccess(presignedUrl));
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "프로필 이미지 저장", description = "이미지 업로드 후(프론트에서 put해야함) URL을 사용자 정보에 반영합니다.")
     @PatchMapping("/profile/image")
     public ResponseEntity<CommonResponse<Void>> updateProfileImage(@RequestParam("imgUrl") String imgUrl) {
         memberService.updateProfileImage(imgUrl);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "회원 닉네임, 출산예정일, 이미지 수정", description = "마이페이지에서 닉네임, 출산 예정일, 프로필 이미지를 수정합니다.")
     @PatchMapping("/profile/edit")
     public ResponseEntity<CommonResponse<Void>> editProfile(@RequestBody ProfileEditRequest request) {
@@ -63,14 +65,14 @@ public class MemberController {
     }
 
 
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "회원정보 조회", description = "현재 로그인한 회원 정보를 조회합니다.")
     @GetMapping("/profile")
     public ResponseEntity<CommonResponse> getMyProfile() {
         return ResponseEntity.ok(CommonResponse.onSuccess(memberService.getMyProfile()));
     }
 
-
+    @PreAuthorize("hasRole('USER')")
     @Operation(summary = "관심 카테고리 변경(단독)", description = "다른 필드 건드리지 않고 관심 카테고리만 교체합니다.")
     @PatchMapping("/profile/categories")
     public ResponseEntity<CommonResponse<Void>> updateCategories(@RequestBody CategoryUpdateRequest req) {

--- a/src/main/java/com/hanium/mom4u/domain/news/controller/NewsController.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/controller/NewsController.java
@@ -77,14 +77,12 @@ public class NewsController {
         );
     }
 
-    @PreAuthorize("hasRole('USER')")
     @PutMapping("/{newsId}/bookmark")
     @Operation(summary = "북마크 추가", description = "해당 정보를 내 북마크에 추가합니다.")
     public ResponseEntity<CommonResponse<?>> addBookmark(@PathVariable Long newsId) {
         newsService.addBookmark(newsId);
         return ResponseEntity.ok(CommonResponse.onSuccess(null));
     }
-    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/{newsId}/bookmark")
     @Operation(summary = "북마크 해제", description = "해당 정보의 북마크를 해제합니다.")
     public ResponseEntity<CommonResponse<?>> removeBookmark(@PathVariable Long newsId) {
@@ -92,7 +90,6 @@ public class NewsController {
         return ResponseEntity.ok(CommonResponse.onSuccess(null));
     }
 
-    @PreAuthorize("hasRole('USER')")
     @GetMapping("/bookmarks")
     @Operation(summary = "내 북마크 목록", description = "로그인 사용자의 북마크한 정보 목록을 조회합니다.")
     public ResponseEntity<CommonResponse<?>> myBookmarks(

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -42,7 +42,7 @@ public enum StatusCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ME4001", "회원을 조회할 수 없습니다."),
     FILE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5001", "파일 저장에 실패했습니다."),
     FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE4002", "파일이 비어있습니다."),
-
+    MEMBER_ONLY(HttpStatus.UNAUTHORIZED, "ME4002", "회원권한이 없습니다."),
 
     //code
     DUPLICATE_FAMILY_CODE(HttpStatus.CONFLICT, "FE4002", "이미 사용 중인 가족 코드입니다."),

--- a/src/main/java/com/hanium/mom4u/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/security/config/SecurityConfig.java
@@ -49,6 +49,9 @@ public class SecurityConfig {
                                 "/actuator/**",
                                 "/api/v1/scan")
                         .permitAll()
+                        .requestMatchers("/api/v1/schedules/**").hasRole("USER")
+                        .requestMatchers("/api/v1/family-code/**").hasRole("USER")
+                        .requestMatchers("/api/v1/member/**").hasRole("USER")
                         .requestMatchers(HttpMethod.PUT,    "/api/v1/news/*/bookmark").hasRole("USER")
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/news/*/bookmark").hasRole("USER")
                         .requestMatchers(HttpMethod.GET,    "/api/v1/news/bookmarks").hasRole("USER")
@@ -78,7 +81,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowedOrigins(List.of("http://localhost:3000", "https://dearbelly.site"));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
 

--- a/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
@@ -12,11 +12,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
-
 import java.security.Key;
-import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 @Component
 public class JwtTokenProvider {
@@ -72,13 +72,13 @@ public class JwtTokenProvider {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
 
-        String roleName = member.getRole().name(); // USER, ADMIN
+        String roleName = member.getRole().name(); // enum 값 (ROLE_USER 또는 ROLE_ADMIN)
         if (!roleName.startsWith("ROLE_")) {
-            roleName = "ROLE_" + roleName;         // → ROLE_USER
+            roleName = "ROLE_" + roleName;
         }
-        var authorities = java.util.List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority(roleName));
+        var authorities = List.of(new SimpleGrantedAuthority(roleName));
 
-        return new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(
+        return new UsernamePasswordAuthenticationToken(
                 member.getId().toString(), null, authorities
         );
     }

--- a/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/hanium/mom4u/global/security/jwt/JwtTokenProvider.java
@@ -21,6 +21,8 @@ import java.util.List;
 @Component
 public class JwtTokenProvider {
 
+    private static final String ROLES_CLAIM = "roles";
+
     @Value("${spring.jwt.secret}")
     private String secretKey;
 
@@ -44,12 +46,12 @@ public class JwtTokenProvider {
     }
 
     public String createAccessToken(Long memberId, Role role) {
-        Claims claims = Jwts.claims().setSubject(memberId.toString());
-        claims.put("role", role);
         Date now = new Date();
         Date validity = new Date(now.getTime() + accessTokenValidityInSeconds * 1000);
+
         return Jwts.builder()
-                .setClaims(claims)
+                .setSubject(memberId.toString())
+                .claim(ROLES_CLAIM, List.of(role.name()))
                 .setIssuedAt(now)
                 .setExpiration(validity)
                 .signWith(key, SignatureAlgorithm.HS256)
@@ -68,21 +70,30 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthentication(String token) {
-        Long memberId = Long.valueOf(getMemberId(token));
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
 
-        String roleName = member.getRole().name(); // enum 값 (ROLE_USER 또는 ROLE_ADMIN)
-        if (!roleName.startsWith("ROLE_")) {
-            roleName = "ROLE_" + roleName;
+        String memberId = claims.getSubject();
+
+        // 토큰의 roles 클레임 사용
+        List<String> roles = claims.get(ROLES_CLAIM, List.class);
+
+        // 예전 토큰 등 roles가 없으면 DB fallback (정합성↑)
+        if (roles == null || roles.isEmpty()) {
+            Member member = memberRepository.findById(Long.valueOf(memberId))
+                    .orElseThrow(() -> GeneralException.of(StatusCode.MEMBER_NOT_FOUND));
+            roles = List.of(member.getRole().name());
         }
-        var authorities = List.of(new SimpleGrantedAuthority(roleName));
 
-        return new UsernamePasswordAuthenticationToken(
-                member.getId().toString(), null, authorities
-        );
+        var authorities = roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+
+        return new UsernamePasswordAuthenticationToken(memberId, null, authorities);
     }
-
 
     public String getMemberId(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build()
@@ -100,10 +111,10 @@ public class JwtTokenProvider {
         }
     }
 
-
     public String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
-        return (bearerToken != null && bearerToken.startsWith("Bearer ")) ?
-                bearerToken.substring(7) : null;
+        return (bearerToken != null && bearerToken.startsWith("Bearer "))
+                ? bearerToken.substring(7)
+                : null;
     }
 }


### PR DESCRIPTION
## 📌 작업 목적

회원/비회원 구분을 표준 401/403 흐름으로 하여, 보호 API는 로그인 필요(401), 권한 부족은 403으로 일관되게 응답하도록 Spring Security 구성을 리팩터링했습니다.
컨트롤러 곳곳의 @PreAuthorize 중복도 정리하여 URL 단위 정책으로 유지보수를 쉽게 했습니다.

---

## 🗂 작업 유형

- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [x] 리팩터링 (Refactor)

---

## 🔨 주요 작업 내용

JwtAuthenticationFilter 리팩터링
- 익명 토큰 주입 제거: AnonymousAuthenticationToken 주입을 삭제하고, 토큰 없거나 무효 시 SecurityContext만 정리하도록 변경

- 검증 예외 시 request.setAttribute("auth_error_status", …)로 사유 전달(만료/무효 구분)

- 필터에서 응답 바디를 직접 쓰지 않음 → ExceptionTranslationFilter 표준 흐름 유지

SecurityConfig 개선

-  requestMatchers("/api/v1/schedules/**").hasRole("USER") 등 URL 단위 인가 규칙으로 일괄 적용

- 공개 API는 permitAll()로 명확히 구분 (예: GET /api/v1/news/**)

- authenticationEntryPoint=401, accessDeniedHandler=403로 역할 고정

- 공통 writeError(...)로 ErrorResponse 포맷 일원화


JWT 토큰/인가 정합성

- access 토큰에 roles 클레임 포함(["ROLE_USER"])


컨트롤러 보안 단순화

- 메서드마다 중복되던 @PreAuthorize("hasRole('USER')") 제거


---

## 🧪 테스트 결과


### 회원권한이 필요한 경우
<img width="977" height="342" alt="image" src="https://github.com/user-attachments/assets/da20ca5a-51b7-45e1-a724-1146a12c8946" />



---

## 📎 관련 이슈

#87 

---

## 💬 논의 및 고민한 점

- schedules, member, baby, family-code, 북마크에 경우에는 회원접근으로 설정했습니다.
- 기존 홈페이지 부분은 구분하지 않았습니다.
 

---

## ✅ 체크리스트
- [x] 관련 이슈와 커밋이 명확히 연결되어 있습니다  
