### PR TITLE
[FIX] Spring 컨테이너 OOM 문제 해결

### DIFF
--- a/deploy/docker/docker-compose.blue.yml
+++ b/deploy/docker/docker-compose.blue.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "8080:8080"
     env_file:
-      - /home/ubuntu/dearbelly-api/deploy/.env
+      - /home/ubuntu/dearbelly-api/docker/.env
     volumes:
       - /home/ubuntu/logs:/app/logs
       - /home/ubuntu/dearbelly-api:/home/dearbelly
@@ -13,6 +13,19 @@ services:
     depends_on:
       - redis
     container_name: app-blue
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+    environment:
+      JAVA_TOOL_OPTIONS: >
+        -XX:+UseG1GC
+        -XX:MaxRAMPercentage=65.0
+        -XX:InitiatingHeapOccupancyPercent=30
+        -XX:MaxGCPauseMillis=200
+        -XX:+UseStringDeduplication
+        -Xss512k
+        -XX:MaxMetaspaceSize=256m
 
   redis:
     image: redis:7.4.1

--- a/deploy/docker/docker-compose.green.yml
+++ b/deploy/docker/docker-compose.green.yml
@@ -4,13 +4,26 @@ services:
     ports:
       - "8081:8080"
     env_file:
-      - /home/ubuntu/dearbelly-api/deploy/.env
+      - /home/ubuntu/dearbelly-api/docker/.env
     volumes:
       - /home/ubuntu/logs:/app/logs
       - /home/ubuntu/dearbelly-api:/home/dearbelly
     networks:
       - mynetwork
     container_name: app-green
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+    environment:
+      JAVA_TOOL_OPTIONS: >
+        -XX:+UseG1GC
+        -XX:MaxRAMPercentage=65.0
+        -XX:InitiatingHeapOccupancyPercent=30
+        -XX:MaxGCPauseMillis=200
+        -XX:+UseStringDeduplication
+        -Xss512k
+        -XX:MaxMetaspaceSize=256m
 
 networks:
   mynetwork:

--- a/src/main/java/com/hanium/mom4u/external/s3/service/FileStorageService.java
+++ b/src/main/java/com/hanium/mom4u/external/s3/service/FileStorageService.java
@@ -133,7 +133,6 @@ public class FileStorageService {
      * S3에 받은 이미지를 업로드 후 PresignedURL 반환
      * 업로드한 이미지의 이름은 JOB의 CorrelationID를 사용
      */
-    @Transactional
     public S3ScanFolderResponseDto uploadFileAndGetPresignedUrl(
             MultipartFile multipartFile, String correlationId) throws IOException {
 

--- a/src/main/resources/logback-dev.yml
+++ b/src/main/resources/logback-dev.yml
@@ -1,2 +1,2 @@
 log.config.level=INFO
-log.config.path=./logs
+log.config.path=/app/logs


### PR DESCRIPTION
## 📌 작업 목적

- 컨테이너의 CPU 및 서버 전반의 CPU를 모니터링 했을 때에도 문제가 없었는데, 계속해서 서버가 중단되는 장애에 대하여 해결하였습니다.

---

## 🗂 작업 유형
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 리팩터링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포/환경 설정 (Chore)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

- 계속해서 일어나는 서버 중단에 확인을 해보니 메모리의 문제였습니다. 전체 메모리의 문제가 아닌 컨테이너 자체에서의 메모리 할당에 대한 문제였습니다.
 
<img width="1139" height="244" alt="image" src="https://github.com/user-attachments/assets/82154d74-a3fa-4421-b0d6-ab692f192bd7" />

- 위의 사진과 같이 전체 메모리 상으로는 문제가 되지 않았으나, 컨테이너 자체에 할당된 문제가 존재했습니다.

<br>

- 직접 컨테이너 환경에 들어가 heap info에 대한 조회 결과
```
from space 4480K, 79% used
// 생략...
 to space 4480K,0x00000000f37a0000) tenured generation total 90024K, used 88173K
// 생략...
 the space 90024K, 97% used [0x00000000f6000000,
```
- 위와 같이 Old(Tenured) 영역이 97%라서 곧바로 FullGC가 떠서 OOM으로 이어지고, 이것이 서버에 영향을 주고 인스턴스 자체가 중단되었습니다.

<br>
<br>
- 해결방법 : container 자체의 메모리 설정

```yaml
    deploy:
      resources:
        limits:
          memory: 2g
```
- 우선은 컨테이너에 여유 메모리를 늘렸습니다.

<br>

- 서버에서 직접 변경하여 실행하여 차이를 확인하였습니다
- 기존

```
the space 90024K,  97% used
```

- 개선
```
   the space 100132K,  78% used 
```
- 그리고 최종적으로 JVM/GC 튜닝도 추가하여 컨테이너 환경 2Gi 기준 안정적인 버전에 대한 옵션을 추가하였습니다.

<br>

---

## 📎 관련 이슈
- Closes #112 
---

## 💬 논의 및 고민한 점
- 서버에서 직접 실행하여 정상 작동 확인했습니다
- 스레드 관리도 추가해서 지난번보다 좀더 성능 개선

---

