### PR TITLE
[REFACTOR] HMAC 서명 기반 가족 코드와 활성화 코드 재사용

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/family/service/FamilyService.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/service/FamilyService.java
@@ -9,15 +9,18 @@ import com.hanium.mom4u.global.exception.BusinessException;
 import com.hanium.mom4u.global.response.StatusCode;
 import com.hanium.mom4u.global.security.jwt.AuthenticatedProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
 
-import java.util.Optional;
 
 
 @Service
@@ -31,9 +34,12 @@ public class FamilyService {
 
     private static final Duration CODE_EXPIRATION = Duration.ofMinutes(3);
 
-
+    @Value("${spring.security.hmac.family-secret}")
+    private String secretKey;
     private static final String CODE_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     private static final int CODE_LENGTH = 10;
+    private static final String REDIS_KEY_PREFIX = "FAMILY_CODE:";
+
 
     private String generateRandomCode() {
         StringBuilder code = new StringBuilder();
@@ -45,6 +51,17 @@ public class FamilyService {
         }
 
         return code.toString();
+    }
+
+    private String createHmacSignature(String data) {
+        try {
+            Mac sha256_HMAC = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secret_key = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+            sha256_HMAC.init(secret_key);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(sha256_HMAC.doFinal(data.getBytes("UTF-8")));
+        } catch (Exception e) {
+            throw new BusinessException(StatusCode.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // 코드 생성
@@ -70,16 +87,30 @@ public class FamilyService {
             memberRepository.save(member);
         }
 
+        // 1. Redis에 유효한 코드가 있는지 확인
+        String existingCode = redisStringTemplate.opsForValue().get(REDIS_KEY_PREFIX + family.getId());
+        if (existingCode != null) {
+            // 2. 유효한 코드가 있으면 해당 코드 반환 (재사용)
+            return existingCode;
+        }
+
+
         // 코드 생성
         String code;
+        String combinedCode;
         do {
             code = generateRandomCode();
-        } while (Boolean.TRUE.equals(redisStringTemplate.hasKey("FAMILY_CODE:" + code)));
+            String hmac = createHmacSignature(code);
+            combinedCode = code + "." + hmac;
+        } while (Boolean.TRUE.equals(redisStringTemplate.hasKey(REDIS_KEY_PREFIX + combinedCode)));
 
-        redisStringTemplate.opsForList().rightPush("FAMILY_CODE:" + code, member.getId().toString());
-        redisStringTemplate.expire("FAMILY_CODE:" + code, CODE_EXPIRATION);
+        // 새로운 코드와 가족 ID를 Redis에 저장
+        redisStringTemplate.opsForValue().set(REDIS_KEY_PREFIX + combinedCode, family.getId().toString(), CODE_EXPIRATION);
 
-        return code;
+        // 가족 ID를 키로 하여 조합된 코드를 저장 (재사용을 위해)
+        redisStringTemplate.opsForValue().set(REDIS_KEY_PREFIX + family.getId(), combinedCode, CODE_EXPIRATION);
+
+        return combinedCode;
     }
 
 
@@ -88,44 +119,45 @@ public class FamilyService {
     public void joinFamily(String code) {
         Member member = authenticatedProvider.getCurrentMember();
 
-        // 이미 가족이 있는 경우 참여 불가
         if (member.getFamily() != null) {
             throw new BusinessException(StatusCode.ALREADY_IN_FAMILY);
         }
 
-        String key = "FAMILY_CODE:" + code;
-        if (!Boolean.TRUE.equals(redisStringTemplate.hasKey(key))) {
+        if (!code.contains(".")) {
+            throw new BusinessException(StatusCode.INVALID_FAMILY_CODE);
+        }
+        String[] parts = code.split("\\.");
+        String providedCode = parts[0];
+        String providedHmac = parts[1];
+
+        String expectedHmac = createHmacSignature(providedCode);
+        if (!providedHmac.equals(expectedHmac)) {
             throw new BusinessException(StatusCode.INVALID_FAMILY_CODE);
         }
 
-        List<String> userList = redisStringTemplate.opsForList().range(key, 0, -1);
-        if (userList == null || userList.isEmpty()) {
+        String key = REDIS_KEY_PREFIX + code;
+        String familyIdStr = redisStringTemplate.opsForValue().get(key);
+
+        if (familyIdStr == null) {
             throw new BusinessException(StatusCode.INVALID_FAMILY_CODE);
         }
 
-        if (!userList.contains(member.getId().toString())) {
-            redisStringTemplate.opsForList().rightPush(key, member.getId().toString());
-        }
-
-        // 임산부 ID로부터 가족 조회
-        Long pregnantMemberId = Long.parseLong(userList.get(0));
-        Family family = memberRepository.findById(pregnantMemberId)
-                .flatMap(m -> Optional.ofNullable(m.getFamily()))
+        Long familyId = Long.parseLong(familyIdStr);
+        Family family = familyRepository.findById(familyId)
                 .orElseThrow(() -> new BusinessException(StatusCode.UNREGISTERED_FAMILY));
 
         member.assignFamily(family);
         memberRepository.save(member);
     }
 
-
-    //코드 유효성
+    // 코드 유효성
     @Transactional(readOnly = true)
     public List<FamilyMemberResponse> getFamilyMembersByFamily() {
         Member member = authenticatedProvider.getCurrentMember();
         Family family = member.getFamily();
 
         if (family == null) {
-            throw new BusinessException(StatusCode.NOT_IN_FAMILY); // 가족에 속해있지 않은 경우
+            throw new BusinessException(StatusCode.NOT_IN_FAMILY);
         }
 
         return family.getMemberList().stream()
@@ -136,6 +168,5 @@ public class FamilyService {
                         .build())
                 .toList();
     }
-
-
 }
+

--- a/src/main/java/com/hanium/mom4u/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/hanium/mom4u/global/security/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/test/**","/v3/api-docs/**", "/swagger-ui/**",
                                 "/swagger-resources/**",
                                 "/uploads/**",

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -36,6 +36,8 @@ spring:
       client_id: ${GOOGLE_REST_API}
       redirect_uri: ${GOOGLE_LOCAL_CALLBACK}
       secret_key: ${GOOGLE_SECRET_KEY}
+    hmac:
+      family-secret: ${FAMILY_HMAC_SECRET}
 
   data:
     redis:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -37,6 +37,8 @@ spring:
       client_id: ${GOOGLE_REST_API}
       redirect_uri: ${GOOGLE_LOCAL_CALLBACK}
       secret_key: ${GOOGLE_SECRET_KEY}
+    hmac:
+      family-secret: ${FAMILY_HMAC_SECRET}
 
   data:
     redis:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -36,6 +36,8 @@ spring:
       client_id: ${GOOGLE_REST_API}
       redirect_uri: ${GOOGLE_LOCAL_CALLBACK}
       secret_key: ${GOOGLE_SECRET_KEY}
+    hmac:
+      family-secret: ${FAMILY_HMAC_SECRET}
 
   data:
     redis:


### PR DESCRIPTION
## 📌 작업 목적

HMAC 서명 기반의 가족 공유 코드를 도입하고, Redis를 이용해 가족당 동시 활성 코드 개수를 1개로 제한합니다. (3분 TTL, 재사용 로직)

---

## 🗂 작업 유형

- [x] 기능 추가 (Feature)
- [x] 리팩터링 (Refactor)
- [x] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

HMAC-서명 코드 생성

- 10자리 대문자+숫자 랜덤코드(CODE_LENGTH=10) 생성 후 HmacSHA256 서명.

- Base64URL(padding 없음)로 인코딩하여 코드.HMAC(combinedCode) 형태로 발급.

- 시크릿: spring.security.hmac.family-secret.

Redis 저장 & 코드 개수 제한

- 키 구조(3분 TTL):

  - FAMILY_CODE:{combinedCode} → familyId

  - FAMILY_CODE:{familyId} → {combinedCode} (가족당 1개 코드 재사용)
- 동일 가족에 기존 유효 코드가 있으면 새로 만들지 않고 재사용.

참여 검증(join)

  - 코드와 HMAC 분리 → 서버에서 동일 시크릿으로 재계산하여 위변조 방지.

  - Redis 조회로 유효/미유효/만료 판별, ALREADY_IN_FAMILY, INVALID_FAMILY_CODE 등 예외 처리.


---

## 🧪 테스트 결과

수동 검증 가이드

- SCAN 0 MATCH FAMILY_CODE:* COUNT 100 → 두 키가 보여야 정상

  - FAMILY_CODE:{combinedCode} → familyId

  - FAMILY_CODE:{familyId} → {combinedCode}

- GET/TTL로 값·만료 확인

### 코드를 발급했을 때 redis
<img width="793" height="105" alt="스크린샷 2025-09-15 233945" src="https://github.com/user-attachments/assets/5d705352-ba49-4574-8f99-6ddfc299d5c5" />

### 유효한 코드 TTL
<img width="367" height="57" alt="image" src="https://github.com/user-attachments/assets/26900235-f17b-4296-93ea-cf5d26ccbffc" />

### 만료 코드 TTL
<img width="383" height="60" alt="image" src="https://github.com/user-attachments/assets/511d90fe-4c30-452f-bd74-1906c79e9da9" />

### HMAC 검증
<img width="1111" height="48" alt="image" src="https://github.com/user-attachments/assets/2b761a19-a9e3-48c1-be2c-727d2a6d59ea" />


---

## 📎 관련 이슈

- Closes #109 

---

## 💬 논의 및 고민한 점

- DB/Redis에만 의존하지 않고 코드 자체에 무결성을 담아 전달 경로에서 변조되어도 검출 가능한 HMAC를 도입했습니다. 

- 다중 코드 생성 시 Redis 키 존재 여부로 충돌 회피하기 위해 유효한 코드가 있을 시 재사용으로 변경했습니다.

---

## ✅ 체크리스트

- [x] 환경 변수 변경 사항이 문서화되었습니다 (spring.security.hmac.family-secret와 노션에 시크릿 키 추가)

- [x] 관련 이슈와 커밋이 명확히 연결되어 있습니다  
