### PR TITLE
[REFACTOR] S3 Presigned URL Blob 업로드 호환성 개선

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
@@ -61,6 +61,15 @@ public class MemberController {
         memberService.commitProfileImage(req.objectKey());
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
+
+    @Operation(summary = "프로필 이미지 기본값으로 리셋",
+            description = "업로드 없이 기본 이미지로 되돌립니다.")
+    @DeleteMapping("/profile/image")
+    public ResponseEntity<CommonResponse<Void>> resetProfileImage() {
+        memberService.resetProfileImageToDefault();
+        return ResponseEntity.ok(CommonResponse.onSuccess());
+    }
+
     @Operation(summary = "회원 닉네임, 출산예정일 수정", description = "마이페이지에서 닉네임, 출산 예정일을 수정합니다.")
     @PatchMapping("/profile/edit")
     public ResponseEntity<CommonResponse<Void>> editProfile(@RequestBody ProfileEditRequest request) {

--- a/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/controller/MemberController.java
@@ -2,7 +2,9 @@ package com.hanium.mom4u.domain.member.controller;
 
 import com.hanium.mom4u.domain.member.common.Gender;
 import com.hanium.mom4u.domain.member.dto.request.CategoryUpdateRequest;
+import com.hanium.mom4u.domain.member.dto.request.ImageCommitRequest;
 import com.hanium.mom4u.domain.member.dto.request.ProfileEditRequest;
+import com.hanium.mom4u.domain.member.dto.response.UploadUrlResponse;
 import com.hanium.mom4u.domain.member.service.MemberService;
 import com.hanium.mom4u.domain.news.common.Category;
 import com.hanium.mom4u.global.response.CommonResponse;
@@ -11,7 +13,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -41,19 +42,26 @@ public class MemberController {
         memberService.updateProfile(nickname, isPregnant, lmpDate, prePregnant, gender, birth, categories);
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-    @Operation(summary = "프로필 이미지 Presigned URL 발급", description = "이미지를 업로드할 S3 presigned URL을 발급합니다.")
+    @Operation(summary = "프로필 이미지 업로드용 Presigned URL 발급",
+            description = "S3에 업로드할 PUT presigned URL과 objectKey를 발급합니다.")
     @GetMapping("/profile/upload-url")
-    public ResponseEntity<CommonResponse<String>> getPresignedUploadUrl(@RequestParam String filename) {
-        String presignedUrl = memberService.getPresignedUploadUrl(filename);
-        return ResponseEntity.ok(CommonResponse.onSuccess(presignedUrl));
+    public ResponseEntity<CommonResponse<UploadUrlResponse>> getPresignedUploadUrl(@RequestParam String filename) {
+        var res = memberService.issuePresignedPut(filename);
+        return ResponseEntity.ok(CommonResponse.onSuccess(res));
     }
-    @Operation(summary = "프로필 이미지 저장", description = "이미지 업로드 후(프론트에서 put해야함) URL을 사용자 정보에 반영합니다.")
-    @PatchMapping("/profile/image")
-    public ResponseEntity<CommonResponse<Void>> updateProfileImage(@RequestParam("imgUrl") String imgUrl) {
-        memberService.updateProfileImage(imgUrl);
+    @Operation(summary = "프로필 이미지 저장",
+            description = """
+    S3 업로드가 끝난 `objectKey`를 전달하면 서버가 **공개 URL을 확정**하고 **DB에 저장**합니다.<br>
+    - 먼저 `/profile/upload-url`로 `putUrl/objectKey`를 발급받고,<br>
+    - `putUrl`로 S3에 파일을 **PUT 업로드**,<br>
+    - 마지막으로 본 API에 아래 **Request Body**를 보내세요.
+    """)
+    @PostMapping("/profile/image/commit")
+    public ResponseEntity<CommonResponse<Void>> commitProfileImage(@RequestBody ImageCommitRequest req) {
+        memberService.commitProfileImage(req.objectKey());
         return ResponseEntity.ok(CommonResponse.onSuccess());
     }
-    @Operation(summary = "회원 닉네임, 출산예정일, 이미지 수정", description = "마이페이지에서 닉네임, 출산 예정일, 프로필 이미지를 수정합니다.")
+    @Operation(summary = "회원 닉네임, 출산예정일 수정", description = "마이페이지에서 닉네임, 출산 예정일을 수정합니다.")
     @PatchMapping("/profile/edit")
     public ResponseEntity<CommonResponse<Void>> editProfile(@RequestBody ProfileEditRequest request) {
         memberService.editProfile(request);

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/request/ImageCommitRequest.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/request/ImageCommitRequest.java
@@ -1,0 +1,8 @@
+package com.hanium.mom4u.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+@Schema(description = "프로필 이미지 커밋 요청 바디")
+public record ImageCommitRequest(
+        @Schema(description = "업로드 완료된 S3 objectKey", example = "images/14/qq")
+        String objectKey
+) {}

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/request/ProfileEditRequest.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/request/ProfileEditRequest.java
@@ -14,6 +14,4 @@ public class ProfileEditRequest {
     @Schema(description = "마지막 생리 시작일")
     private LocalDate lmpDate;
 
-    @Schema(description = "프로필 이미지 URL")
-    private String imgUrl;
 }

--- a/src/main/java/com/hanium/mom4u/domain/member/dto/response/UploadUrlResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/dto/response/UploadUrlResponse.java
@@ -1,0 +1,12 @@
+package com.hanium.mom4u.domain.member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "S3 업로드용 Presigned URL 응답")
+public record UploadUrlResponse(
+        @Schema(description = "S3 PUT Presigned URL")
+        String putUrl,
+        @Schema(description = "업로드될 S3 objectKey", example = "images/14/qq")
+        String objectKey
+) {}
+

--- a/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/service/MemberService.java
@@ -98,17 +98,13 @@ public class MemberService {
     private void deleteIfCustomImage(String imageUrl) {
         if (imageUrl != null && !imageUrl.isBlank()
                 && !imageUrl.equals(DEFAULT_PROFILE_IMG_URL)) {
-            String objectKey = extractKeyFromUrl(imageUrl);
-            fileStorageService.deleteFile(objectKey);
+            String objectKey = fileStorageService.extractKeyFromUrlOrKey(imageUrl); // ← 변경
+            if (!objectKey.isBlank()) {
+                fileStorageService.deleteFile(objectKey);
+            }
         }
     }
 
-
-    private String extractKeyFromUrl(String fullUrl) {
-        int index = fullUrl.indexOf(".amazonaws.com/");
-        if (index == -1) return ""; // 예외 처리
-        return fullUrl.substring(index + ".amazonaws.com/".length());
-    }
 
     public void editProfile(ProfileEditRequest request) {
         Member member = authenticatedProvider.getCurrentMember();

--- a/src/main/java/com/hanium/mom4u/domain/news/dto/response/NewsDetailResponseDto.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/dto/response/NewsDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.hanium.mom4u.domain.news.dto.response;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hanium.mom4u.domain.news.common.Category;
 import com.hanium.mom4u.domain.news.entity.News;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -36,5 +37,10 @@ public class NewsDetailResponseDto {
                 .link(news.getLink())
                 .bookmarked(bookmarked)
                 .build();
+    }
+
+    @JsonProperty("imgUrl")
+    public String getImgUrlAlias() {
+        return imageUrl;
     }
 }

--- a/src/main/java/com/hanium/mom4u/domain/news/dto/response/NewsPreviewResponseDto.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/dto/response/NewsPreviewResponseDto.java
@@ -1,5 +1,6 @@
 package com.hanium.mom4u.domain.news.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hanium.mom4u.domain.news.common.Category;
 import com.hanium.mom4u.domain.news.entity.News;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -31,5 +32,9 @@ public class NewsPreviewResponseDto {
                 .imageUrl(news.getImgUrl())
                 .bookmarked(bookmarked)
                 .build();
+    }
+    @JsonProperty("imgUrl")
+    public String getImgUrlAlias() {
+        return imageUrl;
     }
 }

--- a/src/main/java/com/hanium/mom4u/external/s3/service/FileStorageService.java
+++ b/src/main/java/com/hanium/mom4u/external/s3/service/FileStorageService.java
@@ -42,19 +42,7 @@ public class FileStorageService {
     private final static String S3_IMG_PATH = "scan/";
 
     public String generatePresignedPutUrl(String objectKey) {
-        S3Presigner presigner;
-
-        if (accessKey != null && !accessKey.isBlank() && secretKey != null && !secretKey.isBlank()) {
-            AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
-            presigner = S3Presigner.builder()
-                    .credentialsProvider(StaticCredentialsProvider.create(credentials))
-                    .region(Region.of(region))
-                    .build();
-        } else {
-            presigner = S3Presigner.builder()
-                    .region(Region.of(region))
-                    .build();
-        }
+        S3Presigner presigner = buildPresigner();
 
         PutObjectRequest objectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
@@ -66,30 +54,28 @@ public class FileStorageService {
                 .signatureDuration(Duration.ofMinutes(5))
                 .build();
 
-        URL presignedPutUrl = presigner.presignPutObject(presignRequest).url();
+        URL url = presigner.presignPutObject(presignRequest).url();
         presigner.close();
-
-        return presignedPutUrl.toString();
+        return url.toString();
     }
 
+    public String publicUrlOf(String objectKey) {
+        return "https://" + bucketName + ".s3." + region + ".amazonaws.com/" + objectKey;
+    }
+    public String extractKeyFromUrlOrKey(String fullUrl) {
+        if (fullUrl == null || fullUrl.isBlank()) return "";
+        int idx = fullUrl.indexOf(".amazonaws.com/");
+        if (idx != -1) {
+            return fullUrl.substring(idx + ".amazonaws.com/".length());
+        }
+        return "";
+    }
 
     public void deleteFile(String objectKey) {
-        S3Client s3Client = S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(
-                        (accessKey != null && secretKey != null) ?
-                                StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)) :
-                                DefaultCredentialsProvider.create()
-                )
-                .build();
-
-        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+        s3Client.deleteObject(DeleteObjectRequest.builder()
                 .bucket(bucketName)
                 .key(objectKey)
-                .build();
-
-        s3Client.deleteObject(deleteRequest);
-        s3Client.close();
+                .build());
     }
 
 
@@ -158,5 +144,13 @@ public class FileStorageService {
                 .objectKey(key)
                 .presignedUrl(presignedUrl)
                 .build();
+    }
+    private S3Presigner buildPresigner() {
+        S3Presigner.Builder builder = S3Presigner.builder().region(Region.of(region));
+        if (accessKey != null && !accessKey.isBlank() && secretKey != null && !secretKey.isBlank()) {
+            AwsCredentials cred = AwsBasicCredentials.create(accessKey, secretKey);
+            builder = builder.credentialsProvider(StaticCredentialsProvider.create(cred));
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -39,6 +39,7 @@ public enum StatusCode {
 
 
     // member
+    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "IMG4001", "허용되지 않은 이미지 URL입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "ME4001", "회원을 조회할 수 없습니다."),
     FILE_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE5001", "파일 저장에 실패했습니다."),
     FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE4002", "파일이 비어있습니다."),


### PR DESCRIPTION
## 📌 작업 목적

기존에는 blob: URL만으로 프로필 이미지를 표시해 새로고침 시 이미지가 사라지는 문제가 있었습니다.

이를 개선하여 S3 영구 URL 기반 관리로 전환 → 프론트에서 blob로 표시 가능하면서도 새로고침 이후에도 이미지가 유지되도록 했습니다.

---

## 🗂 작업 유형
- [x] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [x] 리팩터링 (Refactor)
- [x] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

### 1) 프로필 이미지 업로드/저장 플로우 분리 (PUT Presigned URL + Commit)

**GET /api/v1/member/profile/upload-url?filename=...**
  - S3 PUT presigned URL(putUrl)과 objectKey 발급
<img width="1152" height="280" alt="image" src="https://github.com/user-attachments/assets/0e3011c1-aef1-45c0-a3c9-ceb3ceced649" />


**POST /api/v1/member/profile/image/commit**

  - 요청 바디: `{"objectKey":"images/{memberId}/{safeName}"}`

  - 서버가 objectKey를 기반으로 공개 접근 가능한 S3 URL을 확정하여 DB에 저장

  - (보안) objectKey가 본인 prefix(images/{memberId}/) 인지 검증


**DELETE /api/v1/member/profile/image**

  - 별도 업로드 없이 기본 프로필 이미지로 리셋

  - 기존 커스텀 이미지가 있었다면 S3에서 삭제

결과적으로 DB에는 항상 영구 URL이 저장(이미지 변경 상황 제외하고)되며, 프론트는 필요 시 fetch(imgUrl).blob()으로 blob 표시 가능.
새로고침 시에도 imgUrl을 다시 가져와 그대로 표시되므로 이미지 유지


2) FileStorageService 리팩터링
  - buildPresigner() 도입으로 credentials/region 설정 일원화

  - publicUrlOf(objectKey) 추가: objectKey → 퍼블릭 S3 URL 생성
  
  - extractKeyFromUrlOrKey(...) 유틸 추가(필요 시 사용): URL/키 혼용 입력에 안전하게 대응

3) MemberService 보강

  - commitProfileImage(objectKey) : prefix 검증 + 기존 커스텀 이미지 S3 삭제 + DB 저장

  - resetProfileImageToDefault() : 기본 이미지로 리셋
  
---

## 🧪 테스트 결과

이미지 업로드와 S3 버킷에 저장된 것을 확인할 수 있었지만 프론트에서 직접 확인해봐야 할 거 같습니다.

---

## 📎 관련 이슈
- Closes #118 


---

## 💬 논의 및 고민한 점

- 북마크 영역에서 이미지가 보이지 않았던 문제는 타입 호환성 문제로 추정됩니다.

---

## ✅ 체크리스트
- [x] API 명세서(Swagger/Redoc)가 최신화되었습니다 
- [x] 관련 이슈와 커밋이 명확히 연결되어 있습니다  
