### PR TITLE
[REFACTOR] News Entity 고유성 보장 및 Lambda 구조 개선

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,8 +54,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/docker/*
-          target: /home/ubuntu/dearbelly-api/docker/
+          source: ./deploy/docker
+          target: /home/ubuntu/dearbelly-api/
 
       - name: Transfer nginx file to ec2
         uses: appleboy/scp-action@master
@@ -63,8 +63,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/nginx/*
-          target: /home/ubuntu/nginx/
+          source: ./deploy/nginx
+          target: /home/ubuntu/
 
       - name: Transfer monitoring file to ec2
         uses: appleboy/scp-action@master
@@ -72,8 +72,8 @@ jobs:
           host: ${{ secrets.REMOTE_HOST }}
           username: ${{ secrets.REMOTE_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          source: ./deploy/monitoring/*
-          target: /home/ubuntu/monitoring/
+          source: ./deploy/monitoring
+          target: /home/ubuntu/
 
   deploy:
     runs-on: ubuntu-22.04

--- a/src/main/java/com/hanium/mom4u/domain/news/entity/News.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/entity/News.java
@@ -10,7 +10,15 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Entity
-@Table(name = "news")
+@Table(
+        name = "news",
+        indexes = {
+                @Index(name="idx_post_category", columnList = "post_id, category")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name="uniq_post_category", columnNames = {"post_id", "category"})
+        }
+)
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/listener/NewsScheduler.java
@@ -1,5 +1,9 @@
 package com.hanium.mom4u.domain.news.listener;
 
+import com.hanium.mom4u.domain.news.common.Category;
+import com.hanium.mom4u.domain.news.entity.News;
+import com.hanium.mom4u.domain.news.repository.NewsRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -7,19 +11,44 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class NewsScheduler {
+
     @Value("${spring.cloud.aws.s3.bucket}")
     private String BUCKET_NAME;
 
     private final ApplicationEventPublisher eventPublisher;
 
+    private final NewsRepository newsRepository;
+
+    private static final Map<Category, List<String>> newsMap = new HashMap<>();
+    @Value("${spring.cloud.aws.s3.image-prefix}")
+    private String imagePrefix;
+    private static final String EXTENSION = ".png";
+
+    @PostConstruct
+    private void setNewsMap() {
+        for (Category category : Category.values()) {
+            List<String> imageUrl = new ArrayList<>();
+            for (int i = 1; i <= 3; i++) {
+                imageUrl.add(imagePrefix + category.name() + i + EXTENSION);
+            }
+            newsMap.put(category, imageUrl);
+        }
+    }
+
     @Async("schedulerExecutor")
     @Scheduled(cron = "0 0 4 * * *") // 새벽 4시에 실행
-    public void triggerEvent() {
+    public void triggerSaveEvent() {
         log.info("S3 Importing Event started");
         eventPublisher.publishEvent(new S3JsonImportEvent(this, BUCKET_NAME));
     }

--- a/src/main/java/com/hanium/mom4u/domain/news/listener/S3JsonImportEventHandler.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/listener/S3JsonImportEventHandler.java
@@ -1,6 +1,7 @@
 package com.hanium.mom4u.domain.news.listener;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanium.mom4u.domain.news.common.Category;
 import com.hanium.mom4u.domain.news.repository.NewsJdbcRepository;
 import com.hanium.mom4u.global.crawling.dto.CrawlingResultDto;
 import com.hanium.mom4u.global.exception.GeneralException;
@@ -26,38 +27,45 @@ public class S3JsonImportEventHandler {
     private final S3Client s3Client;
     private final ObjectMapper objectMapper;
     private final NewsJdbcRepository newsJdbcRepository;
-    private static final String NEWS_KEY = "data/preprocessed/";
+    private static final String[] NEWS_KEY = {
+            "data/HEALTH/preprocessed/", "data/FINANCIAL/preprocessed/", "data/PREGNANCY_PLANNING/preprocessed/",
+            "data/CHILD/preprocessed/", "data/EMOTIONAL/preprocessed/"
+    };
 
     @EventListener
     public void importJsonFromS3(S3JsonImportEvent event) {
 
-        ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
-                .bucket(event.getBucketName())
-                .prefix(NEWS_KEY)
-                .build();
+        for (int i = 1; i <= NEWS_KEY.length; i++) {
+            String newsKey = NEWS_KEY[i-1];
 
-        ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
+            ListObjectsV2Request listRequest = ListObjectsV2Request.builder()
+                    .bucket(event.getBucketName())
+                    .prefix(newsKey)
+                    .build();
+            ListObjectsV2Response listResponse = s3Client.listObjectsV2(listRequest);
 
-        List<S3Object> objectList = listResponse.contents();
+            List<S3Object> objectList = listResponse.contents();
 
-        for (S3Object s3Object : objectList) {
-            String key = s3Object.key();
+            for (S3Object s3Object : objectList) {
+                String key = s3Object.key();
 
-            if (!key.endsWith(".json")) {
-                continue; // skip
-            }
-            ResponseInputStream<GetObjectResponse> s3InputStream = s3Client.getObject(GetObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(key)
-                    .build());
+                if (!key.endsWith(".json")) {
+                    continue; // skip
+                }
+                ResponseInputStream<GetObjectResponse> s3InputStream = s3Client.getObject(GetObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(key)
+                        .build());
 
-            try {
-                CrawlingResultDto dto = objectMapper.readValue(s3InputStream, CrawlingResultDto.class);
+                try {
+                    CrawlingResultDto dto = objectMapper.readValue(s3InputStream, CrawlingResultDto.class);
 
-                newsJdbcRepository.save(dto);
-                System.out.printf("PostId: %s 저장 성공\n", dto.getPostId());
-            } catch (IOException e) {
-                throw new GeneralException(StatusCode.JSON_PARSING_ERROR);
+                    Category cat = Category.getCategory(i);
+                    newsJdbcRepository.save(dto, cat);
+                    System.out.printf("카테고리 %s 중 PostId: %s 저장 성공\n", newsKey, dto.getPostId());
+                } catch (IOException e) {
+                    throw new GeneralException(StatusCode.JSON_PARSING_ERROR);
+                }
             }
         }
     }

--- a/src/main/java/com/hanium/mom4u/domain/news/repository/NewsJdbcRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/repository/NewsJdbcRepository.java
@@ -1,5 +1,6 @@
 package com.hanium.mom4u.domain.news.repository;
 
+import com.hanium.mom4u.domain.news.common.Category;
 import com.hanium.mom4u.global.crawling.dto.CrawlingResultDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -11,20 +12,32 @@ import org.springframework.stereotype.Repository;
 public class NewsJdbcRepository {
 
     private final JdbcTemplate jdbcTemplate;
-    public void save(CrawlingResultDto dto) {
+
+    /**
+     * JDBC template를 이용하여 DB에 저장
+     * @param dto
+     * @param category
+     */
+    public void save(CrawlingResultDto dto, Category category) {
+
 
         // 중복 체크
-        String findQuery = "SELECT EXISTS (SELECT 1 FROM news WHERE post_id = ?)";
-        Integer count = jdbcTemplate.queryForObject(findQuery, Integer.class, dto.getPostId());
+        String findQuery = "SELECT EXISTS (SELECT 1 FROM news WHERE post_id = ? AND category = ?)";
+        Integer count = jdbcTemplate.queryForObject(
+                findQuery,
+                Integer.class,
+                dto.getPostId(),
+                category.name()
+        );
 
         if (count != null && count > 0) {
             // 이미 존재
-            System.out.printf("이미 존재하는 post_id: %s, 저장 생략\n", dto.getPostId());
+            System.out.printf("카테고리 %s, 이미 존재하는 post_id: %s, 저장 생략\n", category.getDisplayName(), dto.getPostId());
             return;
         }
 
         // 데이터 삽입
-        String sql = "INSERT INTO news (post_id, title, sub_title, link, content, img_url, posted_at) " +
+        String sql = "INSERT INTO news (post_id, title, sub_title, link, content, posted_at, category) " +
                 "VALUES (? ,?, ?, ?, ?, ?, ?)";
 
         jdbcTemplate.update(sql,
@@ -33,7 +46,7 @@ public class NewsJdbcRepository {
                 dto.getSubTitle(),
                 dto.getLink(),
                 dto.getContent(),
-                dto.getImageUrl(),
-                dto.getPostedAt());
+                dto.getPostedAt(),
+                category.name());
     }
 }

--- a/src/main/java/com/hanium/mom4u/domain/news/repository/NewsRepositoryCustom.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/repository/NewsRepositoryCustom.java
@@ -9,5 +9,8 @@ public interface NewsRepositoryCustom {
 
     // 카테고리 별로 하나씩 보여주기
     List<News> findLatestIdByCategory();
+    // 관심 카테고리 지정에 따라 보여주는 것(최신순)
     List<News> findByCategoryOrderByPostedAt(Category category, int count);
+    // 카테고리 별 반환(최신순)
+    List<News> findAllByCategoryOrderByPostedAt(Category category);
 }

--- a/src/main/java/com/hanium/mom4u/domain/news/repository/NewsRepositoryCustomImpl.java
+++ b/src/main/java/com/hanium/mom4u/domain/news/repository/NewsRepositoryCustomImpl.java
@@ -34,6 +34,11 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
                 .fetch();
     }
 
+    /**
+     * @param category : 보여줄 카테고리
+     * @param count : 보여줄 카테고리의 개수(1, 2, 3)
+     * @return
+     */
     @Override
     public List<News> findByCategoryOrderByPostedAt(Category category, int count) {
 
@@ -42,6 +47,18 @@ public class NewsRepositoryCustomImpl implements NewsRepositoryCustom {
                 .where(news.category.eq(category))
                 .orderBy(news.postedAt.desc())
                 .limit(count)
+                .fetch();
+    }
+
+    /*
+    지정 카테고리 별 전체 News 반환
+     */
+    @Override
+    public List<News> findAllByCategoryOrderByPostedAt(Category category) {
+        return jpaQueryFactory
+                .selectFrom(news)
+                .where(news.category.eq(category))
+                .orderBy(news.postedAt.desc())
                 .fetch();
     }
 }

--- a/src/main/java/com/hanium/mom4u/global/crawling/controller/CrawlTestController.java
+++ b/src/main/java/com/hanium/mom4u/global/crawling/controller/CrawlTestController.java
@@ -18,8 +18,6 @@ public class CrawlTestController {
 
     private final CrawlingTriggerService crawlingTriggerService;
 
-    private final FileStorageService fileStorageService;
-
     private final ApplicationEventPublisher eventPublisher;
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucketName;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -52,6 +52,7 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
         default-image: ${DEFAULT_IMAGE}
+        image-prefix: ${IMAGE_PREFIX}
 
       region:
         static: ${AWS_REGION}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,7 +12,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: false
+    show-sql: true
     properties:
       hibernate:
         format_sql: true
@@ -53,6 +53,7 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
         default-image: ${DEFAULT_IMAGE}
+        image-prefix: ${IMAGE_PREFIX}
 
       region:
         static: ${AWS_REGION}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -52,6 +52,7 @@ spring:
         access-key: ${AWS_ACCESS_KEY}
         secret-key: ${AWS_SECRET_KEY}
         default-image: ${DEFAULT_IMAGE}
+        image-prefix: ${IMAGE_PREFIX}
 
       region:
         static: ${AWS_REGION}


### PR DESCRIPTION
## 📌 작업 목적

- S3에 저장된 내용에 대하여 카테고리 별로 저장할 수 있도록 import에 대하여 수정하였으며, DB에 카테고리에 대한 처리를 추가

---

## 🗂 작업 유형
- [x] 기능 추가 (Feature)
- [ ] 버그 수정 (Bug Fix)
- [x] 리팩터링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포/환경 설정 (Chore)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용

- News Entity에서 다양한 사이트에서 게재된 postId를 수집하는 과정에서 고유성 검증이 제대로 이루어지지 않는 문제 발생(ex. A사이트에서의 postId 100과 B사이트에서의 postId 100 고유성 검증 어렵)
```java
@Table(
        name = "news",
        indexes = {
                @Index(name="idx_post_category", columnList = "post_id, category")
        },
        uniqueConstraints = {
                @UniqueConstraint(name="uniq_post_category", columnNames = {"post_id", "category"})
        }
)
```
- 이를 해결하기 위해 post_id와 category를 복합 인덱스 키로 설정하여 고유성을 보장하도록 수정했습니다
```
Hibernate: 
    create index idx_post_category 
       on news (post_id, category)
```
- News 테이블은 별도의 쓰기 작업이 거의 없고 읽기 성능이 중요한 특성을 가지고 있기에 복합 인덱스 키를 통해 중복 관리 효율을 높였습니다 + 조회 성능 개선

<br>

- 카테고리 별로 데이터 가공하는 Lambda 함수에 대하여 각각의 Lambda 함수로 변경(5개 람다 함수 생성)
<br> (람다 함수 이름 바꾸고싶다,, 🤣 )

<img width="654" height="318" alt="image" src="https://github.com/user-attachments/assets/78f26033-99c6-4166-b740-6f1f7550dee9" />

- 각각의 람다 함수는 각각의 카테고리를 기반으로 한 `data/` 경로에 대한 업로드를 트리거로 작동합니다


<br>

- 중간에 토큰 만료로 인하여 끊김 현상 재처리 로직 추가
```python
def looks_truncated(text: str) -> bool:
    """
    방어적으로 문장 말미가 어색하면 추가 이어받기를 시도할 수 있게 보조 판단.
    """
    if not text:
        return True
    good_endings = (".", "!", "?", "…", "。」", "！”", "？”", "”", "’", ")", "]", "}", "\n")
    if text.strip().endswith(good_endings):
        return False
    if len(text.strip()) < 30:
        return True
    last_line = text.strip().splitlines()[-1]
    return len(last_line) > 0 and not last_line.endswith(good_endings)
```
- looks_truncated 함수를 통하여 이에 대하여 해당된다고 판단하면 다시 검증하도록 최대 재시도 3번에 대한 코드 작성하였습니다.
```python
 while rounds < MAX_CONT_ROUNDS and (finish_reason == "length" or looks_truncated(parts[-1])):
            rounds += 1

            tail_anchor = parts[-1].split("\n\n")[-1][-200:] if parts[-1] else ""
            continue_prompt = (
                "방금 응답이 중간에 끊겼습니다. 아래 앵커 이후부터 자연스럽게 이어서 작성해줘. "
                "앞의 내용을 반복 요약하지 말고 중복 없이 이어가줘.\n\n"
                f"[앵커]\n{tail_anchor}\n\n"
                "[이어쓰기 시작]\n"
            )
```
- 확인 결과 제대로 안 끊겼습니다


<br>

- **`NewsScheduler.java`** : 디자이너 분이 요청하셨던 이미지를 번갈아서 나오는 것에 대한 로직 구현하였습니다
```java
    @PostConstruct
    private void setNewsMap() {
        for (Category category : Category.values()) {
            List<String> imageUrl = new ArrayList<>();
            for (int i = 1; i <= 3; i++) {
                imageUrl.add(imagePrefix + category.name() + i + EXTENSION);
            }
            newsMap.put(category, imageUrl);
        }
    }
```
- imagePrefix로 S3 주소를 추가하고 해당 값들을 카테고리 별로 넣어서 번갈아서 배치하도록 작성했습니다

---

## 🧪 테스트 결과

- 일단 확인해본 결과 끊기는 문제 해결한 것 같은데 좀더 열심히 찾아보겠습니다...

<img width="1099" height="733" alt="image" src="https://github.com/user-attachments/assets/90f2db47-47b7-4097-b8a2-13a862299d51" />


---

## 📎 관련 이슈
- Closes #127 

---

## 💬 논의 및 고민한 점
- 환경변수 추가됐습니다. 노션에 올려뒀습니당
- DB에 100개 질문도 업데이트 했습니다

---
