### PR TITLE
[REFACTOR] Question 로직 분리와 QueryDSL 로 query 개선

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/family/entity/DailyQuestion.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/entity/DailyQuestion.java
@@ -15,8 +15,8 @@ public class DailyQuestion extends BaseEntity {
     @Column(name = "daily_question_id")
     private Long id;
 
-    @Column(name = "question")
-    private String question;
+    @Column(name = "daily_question_text", nullable = false) // ← 그날 배정된 질문 텍스트
+    private String questionText;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "family_id")
@@ -28,6 +28,7 @@ public class DailyQuestion extends BaseEntity {
     @Column(name = "answer")
     private String answer;
 
-    @Column(name = "question_id", nullable = false)
+    @Column(name = "origin_question_id", nullable = false) // ← 원본 Question FK
     private Long questionId;
 }
+

--- a/src/main/java/com/hanium/mom4u/domain/family/entity/Question.java
+++ b/src/main/java/com/hanium/mom4u/domain/family/entity/Question.java
@@ -13,7 +13,7 @@ public class Question extends BaseEntity {
     @Column(name = "question_id")
     private Long id;
 
-    @Column(name = "content")
+    @Column(name = "content", nullable = false)
     private String content;
 
 }

--- a/src/main/java/com/hanium/mom4u/domain/question/dto/response/TodayWriteResponse.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/dto/response/TodayWriteResponse.java
@@ -14,7 +14,7 @@ public class TodayWriteResponse {
     private LocalDate date;           // 오늘 날짜
 
     private Long questionId;          // DailyQuestion.id
-    private String questionContent;   // DailyQuestion.question
+    private String questionText;   // DailyQuestion.question
 
     private Long myLetterId;
     private String myLetterContent;

--- a/src/main/java/com/hanium/mom4u/domain/question/repository/DailyQuestionRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/repository/DailyQuestionRepository.java
@@ -2,59 +2,8 @@ package com.hanium.mom4u.domain.question.repository;
 
 import com.hanium.mom4u.domain.family.entity.DailyQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
-public interface DailyQuestionRepository extends JpaRepository<DailyQuestion, Long> {
-
-    @Query("""
-      select dq from DailyQuestion dq
-      where dq.family.id = :familyId
-        and dq.createdAt between :start and :end
-      order by dq.createdAt desc
-    """)
-    List<DailyQuestion> findLatestForFamily(@Param("familyId") Long familyId,
-                                            @Param("start") LocalDateTime start,
-                                            @Param("end") LocalDateTime end,
-                                            Pageable p);
-
-    @Query("""
-      select dq from DailyQuestion dq
-      where dq.family is null
-        and dq.createdAt between :start and :end
-      order by dq.createdAt desc
-    """)
-    List<DailyQuestion> findLatestGlobal(@Param("start") LocalDateTime start,
-                                         @Param("end") LocalDateTime end,
-                                         Pageable p);
-
-    boolean existsByFamilyIsNullAndCreatedAtBetween(LocalDateTime start, LocalDateTime end);
-
-    @Query(value = """
-    SELECT q.question_id AS id, q.content AS content
-      FROM question q
-     WHERE (:excludeContent IS NULL OR q.content <> :excludeContent)
-     ORDER BY RAND()
-     LIMIT 1
-""", nativeQuery = true)
-    Optional<QuestionPick> pickRandomQuestionExcludingContent(@Param("excludeContent") String excludeContent);
-
-    // 아무거나 1개 (fallback)
-    @Query(value = """
-    SELECT q.question_id AS id, q.content AS content
-      FROM question q
-     ORDER BY RAND()
-     LIMIT 1
-""", nativeQuery = true)
-    Optional<QuestionPick> pickAnyQuestion();
-
-    interface QuestionPick {
-        Long getId();
-        String getContent();
-    }
+public interface DailyQuestionRepository
+        extends JpaRepository<DailyQuestion, Long>, DailyQuestionRepositoryCustom {
 }

--- a/src/main/java/com/hanium/mom4u/domain/question/repository/DailyQuestionRepositoryCustom.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/repository/DailyQuestionRepositoryCustom.java
@@ -1,0 +1,30 @@
+package com.hanium.mom4u.domain.question.repository;
+
+import com.hanium.mom4u.domain.family.entity.DailyQuestion;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DailyQuestionRepositoryCustom {
+
+    // 특정 날짜, 가족 질문 우선 조회 (없으면 전역)
+    Optional<DailyQuestion> findOneForDate(Long familyId, LocalDate date);
+
+    // 특정 날짜, 전역 질문 조회
+    Optional<DailyQuestion> findOneGlobalOn(LocalDate date);
+
+    // 전역 질문 존재 여부
+    boolean existsGlobalOn(LocalDate date);
+
+    // 전일 중복 제외하고 랜덤 질문 뽑기
+    Optional<QuestionPick> pickRandomExcluding(String excludeContent);
+
+    // 아무 질문 1개 랜덤
+    Optional<QuestionPick> pickAny();
+
+    // Projection 인터페이스
+    interface QuestionPick {
+        Long getId();
+        String getContent();
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/repository/DailyQuestionRepositoryImpl.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/repository/DailyQuestionRepositoryImpl.java
@@ -1,0 +1,115 @@
+package com.hanium.mom4u.domain.question.repository;
+
+import com.hanium.mom4u.domain.family.entity.DailyQuestion;
+import com.hanium.mom4u.domain.family.entity.QDailyQuestion;
+import com.hanium.mom4u.domain.family.entity.QQuestion;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyQuestionRepositoryImpl implements DailyQuestionRepositoryCustom {
+
+    private final JPAQueryFactory qf;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Override
+    public Optional<DailyQuestion> findOneForDate(Long familyId, LocalDate date) {
+        if (familyId != null) {
+            var fam = findByDateAndFamily(date, familyId);
+            if (fam.isPresent()) return fam;
+        }
+        return findOneGlobalOn(date);
+    }
+
+    private Optional<DailyQuestion> findByDateAndFamily(LocalDate date, Long familyId) {
+        QDailyQuestion dq = QDailyQuestion.dailyQuestion;
+        LocalDateTime sKst   = date.atStartOfDay(KST).toLocalDateTime();
+        LocalDateTime nextKst = sKst.plusDays(1); // [sKst, nextKst)
+
+        DailyQuestion found = qf.selectFrom(dq)
+                .where(dq.family.id.eq(familyId)
+                        .and(dq.createdAt.goe(sKst))
+                        .and(dq.createdAt.lt(nextKst)))
+                .orderBy(dq.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(found);
+    }
+
+    @Override
+    public Optional<DailyQuestion> findOneGlobalOn(LocalDate date) {
+        QDailyQuestion dq = QDailyQuestion.dailyQuestion;
+        LocalDateTime sKst   = date.atStartOfDay(KST).toLocalDateTime();
+        LocalDateTime nextKst = sKst.plusDays(1); // [sKst, nextKst)
+
+        DailyQuestion found = qf.selectFrom(dq)
+                .where(dq.family.isNull()
+                        .and(dq.createdAt.goe(sKst))
+                        .and(dq.createdAt.lt(nextKst)))
+                .orderBy(dq.createdAt.desc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(found);
+    }
+
+    @Override
+    public boolean existsGlobalOn(LocalDate date) {
+        QDailyQuestion dq = QDailyQuestion.dailyQuestion;
+        LocalDateTime sKst   = date.atStartOfDay(KST).toLocalDateTime();
+        LocalDateTime nextKst = sKst.plusDays(1); // [sKst, nextKst)
+
+        Integer one = qf.selectOne()
+                .from(dq)
+                .where(dq.family.isNull()
+                        .and(dq.createdAt.goe(sKst))
+                        .and(dq.createdAt.lt(nextKst)))
+                .fetchFirst();
+
+        return one != null;
+    }
+
+    @Override
+    public Optional<QuestionPick> pickRandomExcluding(String excludeContent) {
+        QQuestion q = QQuestion.question;
+
+        List<Tuple> rows = qf.select(q.id, q.content)
+                .from(q)
+                .where(excludeContent == null ? null : q.content.ne(excludeContent))
+                .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
+                .limit(1)
+                .fetch();
+
+        return rows.stream().findFirst().map(t -> new QuestionPick() {
+            @Override public Long getId() { return t.get(q.id); }
+            @Override public String getContent() { return t.get(q.content); }
+        });
+    }
+
+    @Override
+    public Optional<QuestionPick> pickAny() {
+        QQuestion q = QQuestion.question;
+
+        Tuple t = qf.select(q.id, q.content)
+                .from(q)
+                .orderBy(Expressions.numberTemplate(Double.class, "RAND()").asc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(t).map(tt -> new QuestionPick() {
+            @Override public Long getId() { return tt.get(q.id); }
+            @Override public String getContent() { return tt.get(q.content); }
+        });
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/service/QuestionService.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/service/QuestionService.java
@@ -1,0 +1,67 @@
+package com.hanium.mom4u.domain.question.service;
+
+import com.hanium.mom4u.domain.family.entity.DailyQuestion;
+import com.hanium.mom4u.domain.question.repository.DailyQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuestionService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private final DailyQuestionRepository dailyQuestionRepository; // JpaRepository + Custom
+
+    /** (전역) 오늘 질문이 없으면 생성 */
+    public void ensureTodayGlobalQuestion() {
+        LocalDate today = LocalDate.now(KST);
+
+        //  QueryDSL Custom 메서드 사용
+        if (dailyQuestionRepository.existsGlobalOn(today)) return;
+
+        // 어제 전역 질문(중복 방지용 텍스트)
+        String yesterday = dailyQuestionRepository.findOneGlobalOn(today.minusDays(1))
+                .map(DailyQuestion::getQuestionText)
+                .orElse(null);
+
+        var pick = dailyQuestionRepository.pickRandomExcluding(yesterday)
+                .or(() -> dailyQuestionRepository.pickAny())
+                .orElseThrow(() -> new IllegalStateException("No questions found"));
+
+        DailyQuestion created = new DailyQuestion();
+        created.setFamily(null);
+        created.setQuestionText(pick.getContent());
+        created.setQuestionId(pick.getId());
+        dailyQuestionRepository.save(created);
+    }
+
+    /** 날짜/가족 기준으로 질문 1건(가족 우선 → 없으면 전역) */
+    @Transactional(readOnly = true)
+    public DailyQuestion getFor(LocalDate date, Long familyIdOrNull) {
+        if (familyIdOrNull != null) {
+            return dailyQuestionRepository.findOneForDate(familyIdOrNull, date)
+                    .or(() -> dailyQuestionRepository.findOneGlobalOn(date))
+                    .orElse(null);
+        }
+        return dailyQuestionRepository.findOneGlobalOn(date).orElse(null);
+    }
+
+    /** 질문 텍스트만 필요할 때 */
+    @Transactional(readOnly = true)
+    public String getTextFor(LocalDate date, Long familyIdOrNull) {
+        DailyQuestion dq = getFor(date, familyIdOrNull);
+        return (dq == null) ? null : dq.getQuestionText();
+    }
+
+    /** 매일 0시 전역 질문 보장 */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void scheduleEnsureToday() {
+        ensureTodayGlobalQuestion();
+    }
+}

--- a/src/main/java/com/hanium/mom4u/domain/question/service/QuestionService.java
+++ b/src/main/java/com/hanium/mom4u/domain/question/service/QuestionService.java
@@ -2,7 +2,11 @@ package com.hanium.mom4u.domain.question.service;
 
 import com.hanium.mom4u.domain.family.entity.DailyQuestion;
 import com.hanium.mom4u.domain.question.repository.DailyQuestionRepository;
+import com.hanium.mom4u.global.exception.GeneralException;
+import com.hanium.mom4u.global.response.StatusCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,38 +14,69 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.ZoneId;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class QuestionService {
 
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
-    private final DailyQuestionRepository dailyQuestionRepository; // JpaRepository + Custom
+    private final DailyQuestionRepository dailyQuestionRepository;
 
-    /** (전역) 오늘 질문이 없으면 생성 */
+    /**  매일 0시: 트리거(신호) */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void scheduleEnsureToday() {
+        log.info("[SCHED] ensureTodayGlobalQuestion START");
+        ensureTodayGlobalQuestionAsync();
+    }
+
+    @Transactional
     public void ensureTodayGlobalQuestion() {
+        ensureTodayGlobalQuestionCore();
+    }
+
+    @Async("asyncExecutor")
+    @Transactional
+    public void ensureTodayGlobalQuestionAsync() {
+        long t0 = System.nanoTime();
+        try {
+            ensureTodayGlobalQuestionCore();
+        } catch (Exception e) {
+            log.error("[SCHED] ensureTodayGlobalQuestion FAILED", e);
+        } finally {
+            long tookMs = (System.nanoTime() - t0) / 1_000_000;
+            log.info("[SCHED] ensureTodayGlobalQuestion END took={}ms", tookMs);
+        }
+    }
+
+    /**전역 ‘오늘 질문’ 없으면 생성 */
+    void ensureTodayGlobalQuestionCore() {
         LocalDate today = LocalDate.now(KST);
 
-        //  QueryDSL Custom 메서드 사용
-        if (dailyQuestionRepository.existsGlobalOn(today)) return;
+        if (dailyQuestionRepository.existsGlobalOn(today)) {
+            log.info("[QUESTION] already exists for date={}", today);
+            return;
+        }
 
-        // 어제 전역 질문(중복 방지용 텍스트)
+        // 어제 전역 질문(중복 방지 텍스트)
         String yesterday = dailyQuestionRepository.findOneGlobalOn(today.minusDays(1))
                 .map(DailyQuestion::getQuestionText)
                 .orElse(null);
 
         var pick = dailyQuestionRepository.pickRandomExcluding(yesterday)
                 .or(() -> dailyQuestionRepository.pickAny())
-                .orElseThrow(() -> new IllegalStateException("No questions found"));
+                .orElseThrow(() -> GeneralException.of(StatusCode.QUESTION_NOT_FOUND));
 
         DailyQuestion created = new DailyQuestion();
-        created.setFamily(null);
+        created.setFamily(null); // 전역
         created.setQuestionText(pick.getContent());
         created.setQuestionId(pick.getId());
         dailyQuestionRepository.save(created);
+
+        log.info("[QUESTION] created global date={} originId={} content='{}'",
+                today, pick.getId(), pick.getContent());
     }
 
-    /** 날짜/가족 기준으로 질문 1건(가족 우선 → 없으면 전역) */
+    /**  날짜/가족 기준 1건 조회 (가족 우선 → 없으면 전역) */
     @Transactional(readOnly = true)
     public DailyQuestion getFor(LocalDate date, Long familyIdOrNull) {
         if (familyIdOrNull != null) {
@@ -52,16 +87,10 @@ public class QuestionService {
         return dailyQuestionRepository.findOneGlobalOn(date).orElse(null);
     }
 
-    /** 질문 텍스트만 필요할 때 */
+    /**  질문 ‘텍스트’만 필요할 때 */
     @Transactional(readOnly = true)
     public String getTextFor(LocalDate date, Long familyIdOrNull) {
         DailyQuestion dq = getFor(date, familyIdOrNull);
         return (dq == null) ? null : dq.getQuestionText();
-    }
-
-    /** 매일 0시 전역 질문 보장 */
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    public void scheduleEnsureToday() {
-        ensureTodayGlobalQuestion();
     }
 }

--- a/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
+++ b/src/main/java/com/hanium/mom4u/global/response/StatusCode.java
@@ -73,6 +73,8 @@ public enum StatusCode {
     LETTER_NOT_FOUND(HttpStatus.NOT_FOUND,    "LE4041", "편지를 찾을 수 없습니다."),
     LETTER_CONTENT_TOO_LONG (HttpStatus.BAD_REQUEST, "LE4002", "편지 내용은 300자 이하여야 합니다."),
     LETTER_TODAY_ALREADY_WRITTEN(HttpStatus.CONFLICT, "LE4091", "오늘은 이미 편지를 작성했습니다."),
+    QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "QU4001", "질문을 찾을 수 없습니다."),
+
 
     // scan
     NOT_ENOUGH_FORMAT(HttpStatus.BAD_REQUEST, "SCAN4001", "유효한 사진 파일 양식이 아닙니다."),

--- a/src/test/java/com/hanium/mom4u/domain/questions/repository/DailyQuestionRepositoryImplTest.java
+++ b/src/test/java/com/hanium/mom4u/domain/questions/repository/DailyQuestionRepositoryImplTest.java
@@ -18,7 +18,6 @@ import org.springframework.test.context.ActiveProfiles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/com/hanium/mom4u/domain/questions/repository/DailyQuestionRepositoryImplTest.java
+++ b/src/test/java/com/hanium/mom4u/domain/questions/repository/DailyQuestionRepositoryImplTest.java
@@ -1,0 +1,148 @@
+package com.hanium.mom4u.domain.questions.repository;
+
+import com.hanium.mom4u.domain.family.entity.DailyQuestion;
+import com.hanium.mom4u.domain.family.entity.Family;
+import com.hanium.mom4u.domain.family.entity.Question;
+import com.hanium.mom4u.domain.question.repository.DailyQuestionRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DataJpaTest
+@Import(DailyQuestionRepositoryImplTest.QuerydslTestConfig.class)
+class DailyQuestionRepositoryImplTest {
+
+    @Autowired EntityManager em;
+    @Autowired DailyQuestionRepository dailyQuestionRepository;
+
+    @TestConfiguration
+    static class QuerydslTestConfig {
+        @Bean JPAQueryFactory jpaQueryFactory(EntityManager em) { return new JPAQueryFactory(em); }
+    }
+
+    // ===== reflection helpers =====
+    private static <T> T newInstance(Class<T> type) {
+        try {
+            Constructor<T> c = type.getDeclaredConstructor();
+            c.setAccessible(true);
+            return c.newInstance();
+        } catch (Exception e) { throw new RuntimeException(e); }
+    }
+    private static void set(Object target, String field, Object value) {
+        Class<?> c = target.getClass();
+        while (c != null) {
+            try {
+                Field f = c.getDeclaredField(field);
+                f.setAccessible(true);
+                f.set(target, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                c = c.getSuperclass();
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        throw new RuntimeException(new NoSuchFieldException(field));
+    }
+
+    private Question newQuestion(String content) {
+        Question q = newInstance(Question.class);
+        set(q, "content", content);
+        em.persist(q);
+        em.flush();
+        return q;
+    }
+
+    private Family newFamily() {
+        Family f = newInstance(Family.class);
+        em.persist(f);
+        em.flush();
+        return f;
+    }
+
+    /**
+     * createdAt은 @PrePersist/감사로 now()가 들어갈 수 있으니,
+     * 테스트에서는 굳이 세팅하지 않고 DB now 기반으로 검증합니다.
+     */
+    private DailyQuestion newDailyQuestion(Family fam, String text, Long questionId) {
+        DailyQuestion dq = newInstance(DailyQuestion.class);
+        set(dq, "questionText", text);
+        set(dq, "family", fam);            // fam == null 이면 전역
+        set(dq, "questionId", questionId);
+        em.persist(dq);
+        em.flush();
+        return dq;
+    }
+
+    @Test
+    @DisplayName("findOneForDate: 가족 우선, 없으면 전역")
+    void findOneForDate_prefersFamilyThenGlobal() {
+        LocalDate today = LocalDate.now();   // ★ 핵심: now 기준으로 조회
+        Question q1 = newQuestion("전역질문");
+        Question q2 = newQuestion("가족질문");
+        Family fam = newFamily();
+
+        // 전역 질문
+        newDailyQuestion(null, "전역질문", q1.getId());
+        // 같은 날 가족 질문(더 최신이라는 가정은 어차피 같은 날이므로 createdAt desc로 가족 건이 먼저면 OK)
+        newDailyQuestion(fam, "가족질문", q2.getId());
+
+        em.flush(); em.clear();
+
+        var found = dailyQuestionRepository.findOneForDate(fam.getId(), today);
+        assertThat(found).isPresent();
+        assertThat(found.get().getQuestionText()).isEqualTo("가족질문");
+
+        // 가족 id 없으면 전역으로
+        var globalOnly = dailyQuestionRepository.findOneForDate(null, today);
+        assertThat(globalOnly).isPresent();
+        assertThat(globalOnly.get().getQuestionText()).isEqualTo("전역질문");
+    }
+
+    @Test
+    @DisplayName("existsGlobalOn / findOneGlobalOn")
+    void existsAndFindGlobal() {
+        LocalDate today = LocalDate.now();   // ★ now 기준
+        Question q = newQuestion("전역");
+        newDailyQuestion(null, "전역", q.getId());
+        em.flush(); em.clear();
+
+        boolean exists = dailyQuestionRepository.existsGlobalOn(today);
+        assertThat(exists).isTrue();
+
+        var one = dailyQuestionRepository.findOneGlobalOn(today);
+        assertThat(one).isPresent();
+        assertThat(one.get().getQuestionText()).isEqualTo("전역");
+    }
+
+    @Test
+    @DisplayName("pickRandomExcluding / pickAny")
+    void pickRandom() {
+        Question q1 = newQuestion("A");
+        Question q2 = newQuestion("B");
+        em.flush(); em.clear();
+
+        var excludeA = dailyQuestionRepository.pickRandomExcluding("A");
+        assertThat(excludeA).isPresent();
+        assertThat(excludeA.get().getContent()).isEqualTo("B");
+
+        var anyPick = dailyQuestionRepository.pickAny();
+        assertThat(anyPick).isPresent();
+        assertThat(anyPick.get().getContent()).isIn("A", "B");
+    }
+}

--- a/src/test/java/com/hanium/mom4u/domain/questions/repository/LetterRepositoryTest.java
+++ b/src/test/java/com/hanium/mom4u/domain/questions/repository/LetterRepositoryTest.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 @DataJpaTest
 @Import(LetterRepositoryTest.QuerydslTestConfig.class)
-
 class LetterRepositoryTest {
 
     @Autowired EntityManager em;
@@ -34,10 +33,7 @@ class LetterRepositoryTest {
 
     @TestConfiguration
     static class QuerydslTestConfig {
-        @Bean
-        JPAQueryFactory jpaQueryFactory(EntityManager em) {
-            return new JPAQueryFactory(em);
-        }
+        @Bean JPAQueryFactory jpaQueryFactory(EntityManager em) { return new JPAQueryFactory(em); }
     }
 
     // ====== 리플렉션 헬퍼 ======
@@ -65,7 +61,6 @@ class LetterRepositoryTest {
         throw new RuntimeException(new NoSuchFieldException(field));
     }
 
-
     private Family newFamily() {
         Family f = newInstance(Family.class);
         em.persist(f);
@@ -87,7 +82,6 @@ class LetterRepositoryTest {
                 .writer(writer)
                 .family(family)
                 .build();
-        // createdAt을 persist 전에 주입 (BaseEntity 정책에 따라 updatable=false일 수도 있어서)
         set(l, "createdAt", createdAt);
         em.persist(l);
         return l;
@@ -137,29 +131,6 @@ class LetterRepositoryTest {
         assertThat(list).extracting("content").containsExactly("9/15", "9/1"); // desc 정렬
     }
 
-    @Test
-    @DisplayName("resetSeenFlagForFamilyExceptWriter / markSeenForMember 동작")
-    void seenFlags() {
-        Family fam = newFamily();
-        Member me = newMember(fam, "me", true);
-        Member you = newMember(fam, "you", true);
-
-        em.flush(); em.clear();
-
-        // 나 제외 false
-        letterRepository.resetSeenFlagForFamilyExceptWriter(fam.getId(), me.getId());
-        em.flush(); em.clear();
-
-        Member youReloaded = em.find(Member.class, you.getId());
-        assertThat(youReloaded.isHasSeenFamilyLetters()).isFalse();
-
-        // 나는 true
-        letterRepository.markSeenForMember(me.getId());
-        em.flush(); em.clear();
-
-        Member meReloaded = em.find(Member.class, me.getId());
-        assertThat(meReloaded.isHasSeenFamilyLetters()).isTrue();
-    }
 
     @Test
     @DisplayName("findFeedForUser: 내 개인+가족 편지 섞여 최신순 페이징")

--- a/src/test/java/com/hanium/mom4u/domain/questions/service/QuestionServiceTest.java
+++ b/src/test/java/com/hanium/mom4u/domain/questions/service/QuestionServiceTest.java
@@ -1,0 +1,71 @@
+package com.hanium.mom4u.domain.questions.service;
+
+import com.hanium.mom4u.domain.family.entity.DailyQuestion;
+import com.hanium.mom4u.domain.question.repository.DailyQuestionRepository;
+import com.hanium.mom4u.domain.question.repository.DailyQuestionRepositoryCustom;
+import com.hanium.mom4u.domain.question.service.QuestionService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionServiceTest {
+
+    @Mock DailyQuestionRepository repo;
+    @InjectMocks
+    QuestionService service;
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    @Test
+    void ensureTodayGlobalQuestion_creates_when_absent() {
+        LocalDate today = LocalDate.now(KST);
+        when(repo.existsGlobalOn(today)).thenReturn(false);
+        when(repo.findOneGlobalOn(today.minusDays(1))).thenReturn(Optional.empty());
+        when(repo.pickRandomExcluding(null)).thenReturn(Optional.of(new DailyQuestionRepositoryCustom.QuestionPick() {
+            public Long getId() { return 1L; }
+            public String getContent() { return "랜덤"; }
+        }));
+
+        service.ensureTodayGlobalQuestion();
+
+        verify(repo).save(argThat(dq ->
+                dq.getFamily() == null &&
+                        "랜덤".equals(dq.getQuestionText()) &&
+                        dq.getQuestionId().equals(1L)
+        ));
+    }
+
+    @Test
+    void getFor_family_prefers_family_question() {
+        LocalDate d = LocalDate.now(KST);
+        var famDq = new DailyQuestion();
+        // 주입
+        try {
+            var f = DailyQuestion.class.getDeclaredField("questionText");
+            f.setAccessible(true); f.set(famDq, "FAM");
+        } catch (Exception e) { throw new RuntimeException(e); }
+
+        when(repo.findOneForDate(10L, d)).thenReturn(Optional.of(famDq));
+
+        var result = service.getFor(d, 10L);
+        assertThat(result.getQuestionText()).isEqualTo("FAM");
+    }
+
+    @Test
+    void getTextFor_returns_null_when_absent() {
+        LocalDate d = LocalDate.now(KST);
+        when(repo.findOneGlobalOn(d)).thenReturn(Optional.empty());
+
+        var text = service.getTextFor(d, null);
+        assertThat(text).isNull();
+    }
+}


### PR DESCRIPTION
## 📌 작업 목적

Letter 기능과 Question 로직을 분리하고, 기존 JPA 기반 질의들을 QueryDSL 기반으로 리팩터링하여 가독성과 유지보수성을 개선합니다.

---

## 🗂 작업 유형
- [x] 기능 추가 (Feature)
- [x] 리팩터링 (Refactor)
- [x] 테스트 추가/수정 (Test)


---

## 🔨 주요 작업 내용
## 엔티티
  - Question.content
👉 “질문 데이터베이스에 저장된 원본 문구”

  - DailyQuestion.questionText
👉 “오늘자 배정된 질문 텍스트 (실제 화면에 보여줄 값)”

  - DailyQuestion 엔티티 컬럼명 변경 (questionContent → questionText)
  
<img width="867" height="675" alt="image" src="https://github.com/user-attachments/assets/95ed6a2e-8275-4f31-980d-f7836330e84b" />

## DTO
  - TodayWriteResponse DTO 필드 정리 (questionContent → questionText)
  
## Repository
  - DailyQuestionRepository / Custom / Impl 작성

    - 가족별/전역 질문 조회

가족 우선 → 없으면 전역 폴백
<img width="855" height="190" alt="image" src="https://github.com/user-attachments/assets/34491a61-9907-4f93-9b8a-751697208c77" />

가족기준 조회
<img width="842" height="272" alt="image" src="https://github.com/user-attachments/assets/0e32976d-dc43-43fa-990a-7a94ce7e92ad" />

전역 조회(혼자사용)
<img width="695" height="135" alt="image" src="https://github.com/user-attachments/assets/d7977976-9fdf-4e69-98c4-dd0ad991b0dd" />
    
전일 질문 텍스트 제외하고 랜덤 1건
<img width="821" height="577" alt="image" src="https://github.com/user-attachments/assets/59ce94bf-79a2-4f30-bb04-c661f1818d26" />


  
## Service  
  - QuestionService 구현

    - 오늘 질문 보장 로직 (ensureTodayGlobalQuestion)

    - 날짜/가족 기준 질문 조회

    - 매일 0시 자동 생성 스케줄러 추가


---

## 🧪 테스트 결과

테스트 코드는 통과했는데 추후에 확인해봐야 할 거 같습니다

---

## 📎 관련 이슈
- Closes #132 


---

## 💬 논의 및 고민한 점
- 전역 질문과 가족 질문 우선순위 처리 방식을 가족 → 전역(혼자)으로 했습니다.
- QueryDSL 기반으로 리팩터링하면서 KST 기준 날짜 경계 처리 
  - LocalDate.atStartOfDay() 대신 atStartOfDay(KST) 사용했습니다.
  - 조회 범위를 KST 자정~다음날 자정으로 맞추었습니다.
---

## ✅ 체크리스트
- [x] 모든 단위/통합 테스트를 통과했습니다
- [x] 관련 이슈와 커밋이 명확히 연결되어 있습니다  
