### PR TITLE
[hotfix] Docker volume에 redis.conf 기본 설정 커맨드 누락 수정

### DIFF
--- a/deploy/docker/docker-compose.blue.yml
+++ b/deploy/docker/docker-compose.blue.yml
@@ -33,9 +33,10 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - redis_data:/data
-      - /path/to/redis/redis.conf:/usr/local/etc/redis/redis.conf
+      - /home/ubuntu/deploy/redis/redis-data:/data
+      - /home/ubuntu/deploy/redis/redis.conf:/etc/redis/redis.conf
       - /var/log/redis:/var/log/redis:ro
+    command: ["redis-server", "/etc/redis/redis.conf"]
     networks:
       - mynetwork
     restart: always


### PR DESCRIPTION
## 📌 작업 목적

계속 redis.conf 기본 인식 실패 문제로 인한 원인 해결

---

## 🗂 작업 유형
- [ ] 기능 추가 (Feature)
- [x] 버그 수정 (Bug Fix)
- [ ] 리팩터링 (Refactor)
- [ ] 성능 개선 (Performance)
- [ ] 테스트 추가/수정 (Test)
- [ ] 빌드/배포/환경 설정 (Chore)
- [ ] 문서 수정 (Docs)

---

## 🔨 주요 작업 내용
```yaml
    volumes:
      - /home/ubuntu/deploy/redis/redis.conf:/etc/redis/redis.conf
    command: ["redis-server", "/etc/redis/redis.conf"]
```
- 다음 설정 언제부터인지 누락되어있더라구요,,ㅎㅎ 그래서 redis.conf 볼륨 마운트는 되어도 제대로 conf 기본설정이 안 되고 있었습니다!! 수정했습니다,,

---