### PR TITLE
[FEATURE] 로그인 시 신규회원여부 반환

### DIFF
--- a/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/entity/Member.java
@@ -42,6 +42,9 @@ public class Member extends BaseEntity {
     @Column(name = "social_type")
     private SocialType socialType;
 
+    @Column(name = "provider_id", nullable = false, length = 100)
+    private String providerId;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role")
     private Role role;

--- a/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/hanium/mom4u/domain/member/repository/MemberRepository.java
@@ -34,4 +34,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     """)
     Optional<Member> findWithFamilyAndMembers(@Param("id") Long id);
 
+    Optional<Member> findBySocialTypeAndProviderIdAndIsInactiveFalse(
+            SocialType socialType, String providerId);
 }

--- a/src/main/java/com/hanium/mom4u/global/security/dto/response/GoogleProfileResponseDto.java
+++ b/src/main/java/com/hanium/mom4u/global/security/dto/response/GoogleProfileResponseDto.java
@@ -1,9 +1,10 @@
 package com.hanium.mom4u.global.security.dto.response;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class GoogleProfileResponseDto {
 
     @JsonProperty("id")

--- a/src/main/java/com/hanium/mom4u/global/security/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/hanium/mom4u/global/security/dto/response/LoginResponseDto.java
@@ -13,4 +13,5 @@ public class LoginResponseDto {
     private String email;
     private String nickname;
     private SocialType socialType;
+    private boolean isNew;
 }

--- a/src/main/java/com/hanium/mom4u/global/security/dto/response/NaverProfileResponseDto.java
+++ b/src/main/java/com/hanium/mom4u/global/security/dto/response/NaverProfileResponseDto.java
@@ -1,5 +1,6 @@
 package com.hanium.mom4u.global.security.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
@@ -14,6 +15,7 @@ public class NaverProfileResponseDto {
     public Response response;
 
     @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Response {
         @JsonProperty("id")
         public String id;

--- a/src/main/java/com/hanium/mom4u/global/security/service/NaverLoginService.java
+++ b/src/main/java/com/hanium/mom4u/global/security/service/NaverLoginService.java
@@ -12,6 +12,7 @@ import com.hanium.mom4u.global.security.util.NaverUtil;
 import com.hanium.mom4u.global.security.util.RefreshTokenUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,26 +31,40 @@ public class NaverLoginService {
 
     @Transactional
     public LoginResponseDto loginWithNaver(HttpServletResponse response, String code, String state) {
-        NaverProfileResponseDto profile =
-                naverUtil.findProfile(naverUtil.getToken(code, state).getAccessToken());
+        var token    = naverUtil.getToken(code, state);
+        NaverProfileResponseDto profile = naverUtil.findProfile(token.getAccessToken());
 
-        // 네이버 gender: "M" | "F" | null
-        String naverGender = profile.getResponse().getGender();
-        Gender mappedGender = mapNaverGender(naverGender);
+        String providerId = profile.getResponse().getId();
+        String email      = profile.getResponse().getEmail();
+        String name       = profile.getResponse().getName();
+        String nickname   = profile.getResponse().getNickname();
 
-        Member member = memberRepository
-                .findByEmailAndSocialTypeAndIsInactiveFalse(profile.getResponse().getEmail(), SocialType.NAVER)
-                .orElseGet(() -> {
-                    Member newMember = Member.builder()
-                            .name(profile.getResponse().getName())
-                            .nickname(profile.getResponse().getNickname())
-                            .email(profile.getResponse().getEmail())
-                            .role(Role.ROLE_USER)
-                            .socialType(SocialType.NAVER)
-                            .gender(mappedGender)              //  enum으로 저장
-                            .build();
-                    return memberRepository.save(newMember);
-                });
+        // gender 매핑
+        Gender mappedGender = mapNaverGender(profile.getResponse().getGender());
+
+        //  활성 회원만 조회 → 없으면 신규 생성(탈퇴 이력은 무시)
+        var found = memberRepository.findBySocialTypeAndProviderIdAndIsInactiveFalse(SocialType.NAVER, providerId);
+        boolean isNew = found.isEmpty();
+
+        Member member = found.orElseGet(() -> {
+            Member m = Member.builder()
+                    .socialType(SocialType.NAVER)
+                    .providerId(providerId)   // 핵심 식별자
+                    .email(email)
+                    .name(name)
+                    .nickname(nickname)
+                    .gender(mappedGender)
+                    .role(Role.ROLE_USER)
+                    .isInactive(false)
+                    .build();
+            try {
+                return memberRepository.save(m);
+            } catch (DataIntegrityViolationException e) {
+                // 동시 가입 시 유니크 충돌 대비 멱등 처리
+                return memberRepository.findBySocialTypeAndProviderIdAndIsInactiveFalse(SocialType.NAVER, providerId)
+                        .orElseThrow();
+            }
+        });
 
         // (선택) 기존 회원의 gender가 비어있으면 보정
         if (member.getGender() == null) {
@@ -67,6 +82,7 @@ public class NaverLoginService {
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .socialType(member.getSocialType())
+                .isNew(isNew)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 작업 목적

소셜 로그인 시 신규회원 여부를 반환합니다.
→ 회원가입과 로그인을 구분할 수 있게 하여, 신규 회원일 경우 추가 회원정보 입력 페이지로 유도

---

## 🗂 작업 유형
- [x] 기능 추가 (Feature)
- [x] 리팩터링 (Refactor)

---

## 🔨 주요 작업 내용

- LoginResponseDto에 isNew 필드 추가
- MemberRepository에 findBySocialTypeAndProviderIdAndIsInactiveFalse 메서드 추가
- 각 소셜 로그인 서비스(Kakao/Google/Naver)에서 isNew 여부 판별 후 DTO에 반영


---

## 🧪 테스트 결과

### 기존 회원 로그인 경우
<img width="266" height="318" alt="image" src="https://github.com/user-attachments/assets/9de14902-dfc3-4bc2-b3a0-b9c453f881f3" />

---

## 📎 관련 이슈
- Closes #142 


---

## 💬 논의 및 고민한 점

- socialType + providerId를 조합해 회원여부를 구분

  - socialType + providerId를 조합해 회원을 구분하도록 했습니다.

  - providerId는 각 소셜 플랫폼(카카오, 네이버, 구글)에서 부여하는 고유 식별자로, 동일 계정에서는 변하지 않는 안정적인 값입니다.

  - 다만 동일한 providerId가 다른 소셜 타입(예: 카카오 vs 구글)에서 중복될 가능성을 고려해 socialType까지 함께 조건으로 두어, 각 플랫폼별 고유성을 보장했습니다.
  
- 탈퇴 계정은 isInactive = true로 관리 → 재로그인 시 신규 회원으로 처리되도록 구현

---

## ✅ 체크리스트

- [x] 관련 이슈와 커밋이 명확히 연결되어 있습니다  
